### PR TITLE
Fix normalization and delay solution intervals

### DIFF
--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -421,14 +421,13 @@ def finalize_update(update, params, gain, chan_freqs, t_bin_arr, pf_map_arr,
                 for a in range(n_ant):
                     for d in range(n_dir):
 
-                        t_m = t_bin_arr[t, active_term]
                         f_m = pf_map_arr[f, active_term]
                         d_m = d_map_arr[active_term, d]
 
-                        inter0 = params[t_m, f_m, a, d_m, 0, 0]
-                        inter1 = params[t_m, f_m, a, d_m, 0, -1]
-                        delay0 = params[t_m, f_m, a, d_m, 1, 0]
-                        delay1 = params[t_m, f_m, a, d_m, 1, -1]
+                        inter0 = params[t, f_m, a, d_m, 0, 0]
+                        inter1 = params[t, f_m, a, d_m, 0, -1]
+                        delay0 = params[t, f_m, a, d_m, 1, 0]
+                        delay1 = params[t, f_m, a, d_m, 1, -1]
 
                         cf = chan_freqs[f]
 

--- a/quartical/gains/delay/slow_kernel.py
+++ b/quartical/gains/delay/slow_kernel.py
@@ -394,14 +394,13 @@ def finalize_update(update, params, gain, chan_freqs, t_bin_arr, f_map_arr_p,
                     for a in range(n_ant):
                         for d in range(n_dir):
 
-                            t_m = t_bin_arr[t, active_term]
                             f_m = f_map_arr_p[f, active_term]
                             d_m = d_map_arr[active_term, d]
 
-                            inter0 = params[t_m, f_m, a, d_m, 0, 0]
-                            inter1 = params[t_m, f_m, a, d_m, 0, -1]
-                            delay0 = params[t_m, f_m, a, d_m, 1, 0]
-                            delay1 = params[t_m, f_m, a, d_m, 1, -1]
+                            inter0 = params[t, f_m, a, d_m, 0, 0]
+                            inter1 = params[t, f_m, a, d_m, 0, -1]
+                            delay0 = params[t, f_m, a, d_m, 1, 0]
+                            delay1 = params[t, f_m, a, d_m, 1, -1]
 
                             cf = chan_freqs[f]
 
@@ -425,12 +424,11 @@ def finalize_update(update, params, gain, chan_freqs, t_bin_arr, f_map_arr_p,
                     for a in range(n_ant):
                         for d in range(n_dir):
 
-                            t_m = t_bin_arr[t, active_term]
                             f_m = f_map_arr_p[f, active_term]
                             d_m = d_map_arr[active_term, d]
 
-                            inter0 = params[t_m, f_m, a, d_m, 0, 0]
-                            delay0 = params[t_m, f_m, a, d_m, 1, 0]
+                            inter0 = params[t, f_m, a, d_m, 0, 0]
+                            delay0 = params[t, f_m, a, d_m, 1, 0]
 
                             cf = chan_freqs[f]
 


### PR DESCRIPTION
As it says on the tin, the time solution intervals were always broken for the delay solvers and I had introduced a normalization bug. This should resolve both.