### PR TITLE
Remove determinant calculation.

### DIFF
--- a/quartical/gains/general/inversion.py
+++ b/quartical/gains/general/inversion.py
@@ -36,14 +36,6 @@ def invert_factory(corr_mode, generalised=False):
 
             Ap, Ax, p, r = buffers
 
-            # TODO: This is expensive and bad. Come up with a better way to
-            # diagnose poorly behaving itervals/directions.
-            det = np.linalg.det(A)
-
-            if np.abs(det) < 1e-6 or ~np.isfinite(det):
-                x[:] = 0
-                return
-
             mat_mul_vec(A, x, Ax)
             r[:] = b
             r -= Ax
@@ -53,7 +45,7 @@ def invert_factory(corr_mode, generalised=False):
             for _ in range(x.size):
                 mat_mul_vec(A, p, Ap)
                 alpha_denom = vecct_mul_vec(p, Ap)
-                if np.abs(alpha_denom) == 0:
+                if alpha_denom.real == 0:
                     x[:] = 0
                     break
                 alpha = r_k / alpha_denom


### PR DESCRIPTION
This removes the determinant calculation inside the CG method. Speeds up "slow" 2x2 solvers. All the determinant is likely to catch is singular matrices - these will likely only occur when a gain has no data points contributing to it. Catching diverging gains will need to be more sophisticated and likely examine the behaviour of the updates themselves.