### PR TITLE
Faster phase terms

### DIFF
--- a/quartical/gains/crosshand_phase/kernel.py
+++ b/quartical/gains/crosshand_phase/kernel.py
@@ -3,7 +3,7 @@ import numpy as np
 from numba import prange, generated_jit
 from quartical.utils.numba import coerce_literal
 from quartical.gains.general.generics import (solver_intermediaries,
-                                              compute_residual_phase,
+                                              compute_amplocked_residual,
                                               per_array_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
@@ -88,7 +88,7 @@ def crosshand_phase_solver(base_args, term_args, meta_args, corr_mode):
 
         for loop_idx in range(max_iter):
 
-            compute_residual_phase(base_args,
+            compute_amplocked_residual(base_args,
                                    solver_imdry,
                                    corr_mode)
 

--- a/quartical/gains/crosshand_phase/kernel.py
+++ b/quartical/gains/crosshand_phase/kernel.py
@@ -89,8 +89,8 @@ def crosshand_phase_solver(base_args, term_args, meta_args, corr_mode):
         for loop_idx in range(max_iter):
 
             compute_amplocked_residual(base_args,
-                                   solver_imdry,
-                                   corr_mode)
+                                       solver_imdry,
+                                       corr_mode)
 
             compute_jhj_jhr(base_args,
                             term_args,
@@ -245,8 +245,6 @@ def compute_jhj_jhr(base_args, term_args, meta_args, solver_imdry, corr_mode):
             lop_qp_arr = valloc(complex_dtype, leading_dims=(n_gdir,))
             rop_qp_arr = valloc(complex_dtype, leading_dims=(n_gdir,))
 
-            norm_factors = valloc(complex_dtype)
-
             tmp_kprod = np.zeros((4, 4), dtype=complex_dtype)
             tmp_jhr = jhr[ti, fi]
             tmp_jhj = jhj[ti, fi]
@@ -334,7 +332,6 @@ def compute_jhj_jhr(base_args, term_args, meta_args, solver_imdry, corr_mode):
                         compute_jhwj_jhwr_elem(lop_pq_d,
                                                rop_pq_d,
                                                w,
-                                               norm_factors,
                                                gains_p[active_term],
                                                tmp_kprod,
                                                r_pq,
@@ -347,7 +344,6 @@ def compute_jhj_jhr(base_args, term_args, meta_args, solver_imdry, corr_mode):
                         compute_jhwj_jhwr_elem(lop_qp_d,
                                                rop_qp_d,
                                                w,
-                                               norm_factors,
                                                gains_q[active_term],
                                                tmp_kprod,
                                                r_qp,
@@ -458,21 +454,14 @@ def param_to_gain_factory(corr_mode):
 def compute_jhwj_jhwr_elem_factory(corr_mode):
 
     v1_imul_v2 = factories.v1_imul_v2_factory(corr_mode)
-    imul = factories.imul_factory(corr_mode)
     a_kron_bt = factories.a_kron_bt_factory(corr_mode)
     unpack = factories.unpack_factory(corr_mode)
     unpackc = factories.unpackc_factory(corr_mode)
-    iabsdiv = factories.iabsdiv_factory(corr_mode)
 
     if corr_mode.literal_value == 4:
-        def impl(lop, rop, w, normf, gain, tmp_kprod, res, jhr, jhj):
-
-            # Compute normalization factor.
-            v1_imul_v2(lop, rop, normf)
-            iabsdiv(normf)
+        def impl(lop, rop, w, gain, tmp_kprod, res, jhr, jhj):
 
             # Accumulate an element of jhwr.
-            imul(res, normf)  # Apply normalization factor to r.
             v1_imul_v2(res, rop, res)
             v1_imul_v2(lop, res, res)
 
@@ -497,13 +486,6 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
             jhr[0] += upd_00
 
             w_0, w_1, w_2, w_3 = unpack(w)  # NOTE: XX, XY, YX, YY
-            n_0, n_1, n_2, n_3 = unpack(normf)
-
-            # Apply normalisation factors by scaling w.
-            w_0 = n_0 * w_0 * n_0
-            w_1 = n_1 * w_1 * n_1
-            w_2 = n_2 * w_2 * n_2
-            w_3 = n_3 * w_3 * n_3
 
             jh_0, jh_1, jh_2, jh_3 = unpack(tmp_kprod[0])
             j_0, j_1, j_2, j_3 = unpackc(tmp_kprod[0])

--- a/quartical/gains/delay/__init__.py
+++ b/quartical/gains/delay/__init__.py
@@ -96,9 +96,8 @@ class Delay(Gain):
         a2 = kwargs["a2"]
         chan_freq = kwargs["chan_freqs"]
         t_map = kwargs["t_map_arr"][0, :, term_ind]  # time -> solint
+        f_map = kwargs["f_map_arr"][1, :, term_ind]  # freq -> solint
         _, n_chan, n_ant, n_dir, n_corr = gain.shape
-        # TODO: Make controllable/automate. Check with Landman.
-        pad_factor = int(np.ceil(2 ** 15 / n_chan))
 
         # We only need the baselines which include the ref_ant.
         sel = np.where((a1 == ref_ant) | (a2 == ref_ant))
@@ -111,12 +110,14 @@ class Delay(Gain):
         data[flags != 0] = 0
 
         utint = np.unique(t_map)
+        ufint = np.unique(f_map)
 
         for ut in utint:
             sel = np.where((t_map == ut) & (a1 != a2))
             ant_map_pq = np.where(a1[sel] == ref_ant, a2[sel], 0)
             ant_map_qp = np.where(a2[sel] == ref_ant, a1[sel], 0)
             ant_map = ant_map_pq + ant_map_qp
+
             ref_data = np.zeros((n_ant, n_chan, n_corr), dtype=np.complex128)
             counts = np.zeros((n_ant, n_chan), dtype=int)
             np.add.at(
@@ -136,35 +137,44 @@ class Delay(Gain):
                 out=ref_data
             )
 
-            fft_data = np.abs(
-                np.fft.fft(ref_data, n=n_chan*pad_factor, axis=1)
-            )
-            fft_data = np.fft.fftshift(fft_data, axes=1)
+            for uf in ufint:
 
-            delta_freq = chan_freq[1] - chan_freq[0]
-            fft_freq = np.fft.fftfreq(n_chan*pad_factor, delta_freq)
-            fft_freq = np.fft.fftshift(fft_freq)
+                fsel = np.where(f_map == uf)[0]
+                sel_n_chan = fsel.size
+                n = int(np.ceil(2 ** 15 / sel_n_chan)) * sel_n_chan
 
-            delay_est_ind_00 = np.argmax(fft_data[..., 0], axis=1)
-            delay_est_00 = fft_freq[delay_est_ind_00]
+                fft_data = np.abs(
+                    np.fft.fft(ref_data[:, fsel], n=n, axis=1)
+                )
+                fft_data = np.fft.fftshift(fft_data, axes=1)
 
-            if n_corr > 1:
-                delay_est_ind_11 = np.argmax(fft_data[..., -1], axis=1)
-                delay_est_11 = fft_freq[delay_est_ind_11]
+                delta_freq = chan_freq[1] - chan_freq[0]
+                fft_freq = np.fft.fftfreq(n, delta_freq)
+                fft_freq = np.fft.fftshift(fft_freq)
 
-            for t, p, q in zip(t_map[sel], a1[sel], a2[sel]):
-                if p == ref_ant:
-                    param[t, 0, q, 0, 1] = -delay_est_00[q]
-                    if n_corr > 1:
-                        param[t, 0, q, 0, 3] = -delay_est_11[q]
-                else:
-                    param[t, 0, p, 0, 1] = delay_est_00[p]
-                    if n_corr > 1:
-                        param[t, 0, p, 0, 3] = delay_est_11[p]
+                delay_est_ind_00 = np.argmax(fft_data[..., 0], axis=1)
+                delay_est_00 = fft_freq[delay_est_ind_00]
 
-        coeffs00 = param[..., 1]*kwargs["chan_freqs"][None, :,  None, None]
-        gain[..., 0] = np.exp(2j*np.pi*coeffs00)
+                if n_corr > 1:
+                    delay_est_ind_11 = np.argmax(fft_data[..., -1], axis=1)
+                    delay_est_11 = fft_freq[delay_est_ind_11]
 
-        if n_corr > 1:
-            coeffs11 = param[..., 3]*kwargs["chan_freqs"][None, :, None, None]
-            gain[..., -1] = np.exp(2j*np.pi*coeffs11)
+                for t, p, q in zip(t_map[sel], a1[sel], a2[sel]):
+                    if p == ref_ant:
+                        param[t, uf, q, 0, 1] = -delay_est_00[q]
+                        if n_corr > 1:
+                            param[t, uf, q, 0, 3] = -delay_est_11[q]
+                    else:
+                        param[t, uf, p, 0, 1] = delay_est_00[p]
+                        if n_corr > 1:
+                            param[t, uf, p, 0, 3] = delay_est_11[p]
+
+        for ut in utint:
+            for f in range(n_chan):
+                fm = f_map[f]
+                cf = 2j * np.pi * chan_freq[f]
+
+                gain[ut, f, :, :, 0] = np.exp(cf * param[ut, fm, :, :, 1])
+
+                if n_corr > 1:
+                    gain[ut, f, :, :, -1] = np.exp(cf * param[ut, fm, :, :, 3])

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -3,7 +3,7 @@ import numpy as np
 from numba import prange, generated_jit
 from quartical.utils.numba import coerce_literal
 from quartical.gains.general.generics import (solver_intermediaries,
-                                              compute_residual_phase,
+                                              compute_amplocked_residual,
                                               per_array_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
@@ -97,7 +97,7 @@ def delay_solver(base_args, term_args, meta_args, corr_mode):
 
         for loop_idx in range(max_iter):
 
-            compute_residual_phase(base_args,
+            compute_amplocked_residual(base_args,
                                    solver_imdry,
                                    corr_mode)
 

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -261,8 +261,6 @@ def compute_jhj_jhr(base_args, term_args, meta_args, solver_imdry, scaled_cf,
             lop_qp_arr = valloc(complex_dtype, leading_dims=(n_gdir,))
             rop_qp_arr = valloc(complex_dtype, leading_dims=(n_gdir,))
 
-            norm_factors = valloc(complex_dtype)
-
             tmp_kprod = np.zeros((4, 4), dtype=complex_dtype)
             tmp_jhr = jhr[ti, fi]
             tmp_jhj = jhj[ti, fi]
@@ -353,7 +351,6 @@ def compute_jhj_jhr(base_args, term_args, meta_args, solver_imdry, scaled_cf,
                                                rop_pq_d,
                                                w,
                                                nu,
-                                               norm_factors,
                                                gains_p[active_term],
                                                tmp_kprod,
                                                r_pq,
@@ -367,7 +364,6 @@ def compute_jhj_jhr(base_args, term_args, meta_args, solver_imdry, scaled_cf,
                                                rop_qp_d,
                                                w,
                                                nu,
-                                               norm_factors,
                                                gains_q[active_term],
                                                tmp_kprod,
                                                r_qp,
@@ -493,27 +489,19 @@ def param_to_gain_factory(corr_mode):
 def compute_jhwj_jhwr_elem_factory(corr_mode):
 
     v1_imul_v2 = factories.v1_imul_v2_factory(corr_mode)
-    imul = factories.imul_factory(corr_mode)
     a_kron_bt = factories.a_kron_bt_factory(corr_mode)
-    iunpack = factories.iunpack_factory(corr_mode)
     unpack = factories.unpack_factory(corr_mode)
     unpackc = factories.unpackc_factory(corr_mode)
-    iabsdiv = factories.iabsdiv_factory(corr_mode)
 
     if corr_mode.literal_value == 4:
-        def impl(lop, rop, w, nu, normf, gain, tmp_kprod, res, jhr, jhj):
+        def impl(lop, rop, w, nu, gain, tmp_kprod, res, jhr, jhj):
 
             # Effectively apply zero weight to off-diagonal terms.
             # TODO: Can be tidied but requires moving other weighting code.
             res[1] = 0
             res[2] = 0
 
-            # Compute normalization factor.
-            v1_imul_v2(lop, rop, normf)
-            iabsdiv(normf)
-
             # Accumulate an element of jhwr.
-            imul(res, normf)  # Apply normalization factor to r.
             v1_imul_v2(res, rop, res)
             v1_imul_v2(lop, res, res)
 
@@ -544,14 +532,12 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
             jhr[3] += nu*upd_11
 
             w_0, w_1, w_2, w_3 = unpack(w)  # NOTE: XX, XY, YX, YY
-            n_0, n_1, n_2, n_3 = unpack(normf)
 
-            # Apply normalisation factors by scaling w. Neglect (set weight
-            # to zero) off diagonal terms.
-            w_0 = n_0 * w_0 * n_0
+            # Neglect (set weight to zero) off diagonal terms.
+            w_0 = w_0
             w_1 = 0
             w_2 = 0
-            w_3 = n_3 * w_3 * n_3
+            w_3 = w_3
 
             jh_0, jh_1, jh_2, jh_3 = unpack(tmp_kprod[0])
             j_0, j_1, j_2, j_3 = unpackc(tmp_kprod[0])
@@ -591,14 +577,9 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
             jhj[3, 3] += tmp_2*nusq
 
     elif corr_mode.literal_value == 2:
-        def impl(lop, rop, w, nu, normf, gain, tmp_kprod, res, jhr, jhj):
-
-            # Compute normalization factor.
-            iunpack(normf, rop)
-            iabsdiv(normf)
+        def impl(lop, rop, w, nu, gain, tmp_kprod, res, jhr, jhj):
 
             # Accumulate an element of jhwr.
-            imul(res, normf)
             v1_imul_v2(res, rop, res)
 
             r_0, r_1 = unpack(res)
@@ -619,31 +600,25 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
             jh_00, jh_11 = unpack(rop)
             j_00, j_11 = unpackc(rop)
             w_00, w_11 = unpack(w)
-            n_00, n_11 = unpack(normf)
 
             nusq = nu*nu
 
-            tmp = (jh_00*n_00*w_00*n_00*j_00).real
+            tmp = (jh_00*w_00*j_00).real
             jhj[0, 0] += tmp
             jhj[0, 1] += tmp*nu
             jhj[1, 0] += tmp*nu
             jhj[1, 1] += tmp*nusq
 
-            tmp = (jh_11*n_11*w_11*n_11*j_11).real
+            tmp = (jh_11*w_11*j_11).real
             jhj[2, 2] += tmp
             jhj[2, 3] += tmp*nu
             jhj[3, 2] += tmp*nu
             jhj[3, 3] += tmp*nusq
 
     elif corr_mode.literal_value == 1:
-        def impl(lop, rop, w, nu, normf, gain, tmp_kprod, res, jhr, jhj):
-
-            # Compute normalization factor.
-            iunpack(normf, rop)
-            iabsdiv(normf)
+        def impl(lop, rop, w, nu, gain, tmp_kprod, res, jhr, jhj):
 
             # Accumulate an element of jhwr.
-            imul(res, normf)
             v1_imul_v2(res, rop, res)
 
             r_0 = unpack(res)
@@ -660,11 +635,10 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
             jh_00 = unpack(rop)
             j_00 = unpackc(rop)
             w_00 = unpack(w)
-            n_00 = unpack(normf)
 
             nusq = nu*nu
 
-            tmp = (jh_00*n_00*w_00*n_00*j_00).real
+            tmp = (jh_00*w_00*j_00).real
             jhj[0, 0] += tmp
             jhj[0, 1] += tmp*nu
             jhj[1, 0] += tmp*nu

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -98,8 +98,8 @@ def delay_solver(base_args, term_args, meta_args, corr_mode):
         for loop_idx in range(max_iter):
 
             compute_amplocked_residual(base_args,
-                                   solver_imdry,
-                                   corr_mode)
+                                       solver_imdry,
+                                       corr_mode)
 
             compute_jhj_jhr(base_args,
                             term_args,

--- a/quartical/gains/general/factories.py
+++ b/quartical/gains/general/factories.py
@@ -709,6 +709,41 @@ def v1_iabsdiv_v2_factory(mode):
     return qcjit(impl)
 
 
+def absv1_idiv_absv2_factory(mode):
+
+    if mode.literal_value == 4:
+        def impl(v1, v2, o1):
+            o1[0] = 0 if v2[0] == 0 else np.sqrt(
+                (v1[0].real**2 + v1[0].imag**2)/(v2[0].real**2 + v2[0].imag**2)
+            )
+            o1[1] = 0 if v2[1] == 0 else np.sqrt(
+                (v1[1].real**2 + v1[1].imag**2)/(v2[1].real**2 + v2[1].imag**2)
+            )
+            o1[2] = 0 if v2[2] == 0 else np.sqrt(
+                (v1[2].real**2 + v1[2].imag**2)/(v2[2].real**2 + v2[2].imag**2)
+            )
+            o1[3] = 0 if v2[3] == 0 else np.sqrt(
+                (v1[3].real**2 + v1[3].imag**2)/(v2[3].real**2 + v2[3].imag**2)
+            )
+    elif mode.literal_value == 2:
+        def impl(v1, v2, o1):
+            o1[0] = 0 if v2[0] == 0 else np.sqrt(
+                (v1[0].real**2 + v1[0].imag**2)/(v2[0].real**2 + v2[0].imag**2)
+            )
+            o1[1] = 0 if v2[1] == 0 else np.sqrt(
+                (v1[1].real**2 + v1[1].imag**2)/(v2[1].real**2 + v2[1].imag**2)
+            )
+    elif mode.literal_value == 1:
+        def impl(v1, v2, o1):
+            o1[0] = 0 if v2[0] == 0 else np.sqrt(
+                (v1[0].real**2 + v1[0].imag**2)/(v2[0].real**2 + v2[0].imag**2)
+            )
+    else:
+        raise ValueError("Unsupported number of correlations.")
+
+    return qcjit(impl)
+
+
 def a_kron_bt_factory(corr_mode):
 
     unpack = unpack_factory(corr_mode)

--- a/quartical/gains/general/factories.py
+++ b/quartical/gains/general/factories.py
@@ -667,28 +667,7 @@ def iabs_factory(mode):
     return qcjit(impl)
 
 
-def iabsdiv_factory(mode):
-
-    if mode.literal_value == 4:
-        def impl(v1):
-            v1[0] = 0 if v1[0] == 0 else 1/np.abs(v1[0])
-            v1[1] = 0 if v1[1] == 0 else 1/np.abs(v1[1])
-            v1[2] = 0 if v1[2] == 0 else 1/np.abs(v1[2])
-            v1[3] = 0 if v1[3] == 0 else 1/np.abs(v1[3])
-    elif mode.literal_value == 2:
-        def impl(v1):
-            v1[0] = 0 if v1[0] == 0 else 1/np.abs(v1[0])
-            v1[1] = 0 if v1[1] == 0 else 1/np.abs(v1[1])
-    elif mode.literal_value == 1:
-        def impl(v1):
-            v1[0] = 0 if v1[0] == 0 else 1/np.abs(v1[0])
-    else:
-        raise ValueError("Unsupported number of correlations.")
-
-    return qcjit(impl)
-
-
-def v1_iabsdiv_v2_factory(mode):
+def v1_idiv_absv2_factory(mode):
 
     if mode.literal_value == 4:
         def impl(v1, v2, o1):

--- a/quartical/gains/general/generics.py
+++ b/quartical/gains/general/generics.py
@@ -315,7 +315,7 @@ def compute_phaselocked_residual(
     iunpack = factories.iunpack_factory(corr_mode)
     valloc = factories.valloc_factory(corr_mode)
     iabs = factories.iabs_factory(corr_mode)
-    v1_iabsdiv_v2 = factories.v1_iabsdiv_v2_factory(corr_mode)
+    v1_idiv_absv2 = factories.v1_idiv_absv2_factory(corr_mode)
 
     def impl(base_args, solver_imdry, corr_mode, sub_dirs=None):
 
@@ -376,7 +376,7 @@ def compute_phaselocked_residual(
 
                     imul_rweight(v, v, row_weights, row_ind)
 
-                    v1_iabsdiv_v2(v, v, v_phase)
+                    v1_idiv_absv2(v, v, v_phase)
                     imul(r, v_phase)
                     isub(r, v)
 

--- a/quartical/gains/general/generics.py
+++ b/quartical/gains/general/generics.py
@@ -25,6 +25,12 @@ qcgjit = generated_jit(nopython=True,
                        cache=True,
                        nogil=True)
 
+qcgjit_parallel = generated_jit(nopython=True,
+                                fastmath=True,
+                                parallel=True,
+                                cache=True,
+                                nogil=True)
+
 
 @qcgjit
 def invert_gains(gain_list, inverse_gains, corr_mode):
@@ -122,8 +128,13 @@ def compute_residual(data, model, gain_list, a1, a2, t_map_arr, f_map_arr,
     return impl
 
 
-@qcgjit
-def compute_residual_solver(base_args, solver_imdry, corr_mode, sub_dirs=None):
+@qcgjit_parallel
+def compute_residual_solver(
+    base_args,
+    solver_imdry,
+    corr_mode,
+    sub_dirs=None
+):
 
     coerce_literal(compute_residual_solver, ["corr_mode"])
 
@@ -197,7 +208,7 @@ def compute_residual_solver(base_args, solver_imdry, corr_mode, sub_dirs=None):
     return impl
 
 
-@qcgjit
+@qcgjit_parallel
 def compute_amplocked_residual(
     base_args,
     solver_imdry,
@@ -288,7 +299,7 @@ def compute_amplocked_residual(
     return impl
 
 
-@qcgjit
+@qcgjit_parallel
 def compute_phaselocked_residual(
     base_args,
     solver_imdry,

--- a/quartical/gains/general/generics.py
+++ b/quartical/gains/general/generics.py
@@ -198,9 +198,14 @@ def compute_residual_solver(base_args, solver_imdry, corr_mode, sub_dirs=None):
 
 
 @qcgjit
-def compute_residual_phase(base_args, solver_imdry, corr_mode, sub_dirs=None):
+def compute_amplocked_residual(
+    base_args,
+    solver_imdry,
+    corr_mode,
+    sub_dirs=None
+):
 
-    coerce_literal(compute_residual_phase, ["corr_mode"])
+    coerce_literal(compute_amplocked_residual, ["corr_mode"])
 
     # We want to dispatch based on this field so we need its type.
     row_weights = base_args[base_args.fields.index('row_weights')]
@@ -288,7 +293,8 @@ def compute_phaselocked_residual(
     base_args,
     solver_imdry,
     corr_mode,
-    sub_dirs=None):
+    sub_dirs=None
+):
     """A special residual implementation for amplitude only terms.
 
     The phaselocked residual is equivalent to the residual when the phases
@@ -296,7 +302,7 @@ def compute_phaselocked_residual(
     amplitude only solutions.
     """
 
-    coerce_literal(compute_residual_phase, ["corr_mode"])
+    coerce_literal(compute_phaselocked_residual, ["corr_mode"])
 
     # We want to dispatch based on this field so we need its type.
     row_weights = base_args[base_args.fields.index('row_weights')]

--- a/quartical/gains/phase/kernel.py
+++ b/quartical/gains/phase/kernel.py
@@ -90,8 +90,8 @@ def phase_solver(base_args, term_args, meta_args, corr_mode):
         for loop_idx in range(max_iter):
 
             compute_amplocked_residual(base_args,
-                                   solver_imdry,
-                                   corr_mode)
+                                       solver_imdry,
+                                       corr_mode)
 
             compute_jhj_jhr(base_args,
                             term_args,
@@ -246,8 +246,6 @@ def compute_jhj_jhr(base_args, term_args, meta_args, solver_imdry, corr_mode):
             lop_qp_arr = valloc(complex_dtype, leading_dims=(n_gdir,))
             rop_qp_arr = valloc(complex_dtype, leading_dims=(n_gdir,))
 
-            norm_factors = valloc(complex_dtype)
-
             tmp_kprod = np.zeros((4, 4), dtype=complex_dtype)
             tmp_jhr = jhr[ti, fi]
             tmp_jhj = jhj[ti, fi]
@@ -335,7 +333,6 @@ def compute_jhj_jhr(base_args, term_args, meta_args, solver_imdry, corr_mode):
                         compute_jhwj_jhwr_elem(lop_pq_d,
                                                rop_pq_d,
                                                w,
-                                               norm_factors,
                                                gains_p[active_term],
                                                tmp_kprod,
                                                r_pq,
@@ -348,7 +345,6 @@ def compute_jhj_jhr(base_args, term_args, meta_args, solver_imdry, corr_mode):
                         compute_jhwj_jhwr_elem(lop_qp_d,
                                                rop_qp_d,
                                                w,
-                                               norm_factors,
                                                gains_q[active_term],
                                                tmp_kprod,
                                                r_qp,
@@ -466,27 +462,19 @@ def param_to_gain_factory(corr_mode):
 def compute_jhwj_jhwr_elem_factory(corr_mode):
 
     v1_imul_v2 = factories.v1_imul_v2_factory(corr_mode)
-    imul = factories.imul_factory(corr_mode)
     a_kron_bt = factories.a_kron_bt_factory(corr_mode)
-    iunpack = factories.iunpack_factory(corr_mode)
     unpack = factories.unpack_factory(corr_mode)
     unpackc = factories.unpackc_factory(corr_mode)
-    iabsdiv = factories.iabsdiv_factory(corr_mode)
 
     if corr_mode.literal_value == 4:
-        def impl(lop, rop, w, normf, gain, tmp_kprod, res, jhr, jhj):
+        def impl(lop, rop, w, gain, tmp_kprod, res, jhr, jhj):
 
             # Effectively apply zero weight to off-diagonal terms.
             # TODO: Can be tidied but requires moving other weighting code.
             res[1] = 0
             res[2] = 0
 
-            # Compute normalization factor.
-            v1_imul_v2(lop, rop, normf)
-            iabsdiv(normf)
-
             # Accumulate an element of jhwr.
-            imul(res, normf)  # Apply normalization factor to r.
             v1_imul_v2(res, rop, res)
             v1_imul_v2(lop, res, res)
 
@@ -515,14 +503,10 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
             jhr[1] += upd_11
 
             w_0, w_1, w_2, w_3 = unpack(w)  # NOTE: XX, XY, YX, YY
-            n_0, n_1, n_2, n_3 = unpack(normf)
 
-            # Apply normalisation factors by scaling w. Neglect (set weight
-            # to zero) off diagonal terms.
-            w_0 = n_0 * w_0 * n_0
+            # Neglect (set weight to zero) off diagonal terms.
             w_1 = 0
             w_2 = 0
-            w_3 = n_3 * w_3 * n_3
 
             jh_0, jh_1, jh_2, jh_3 = unpack(tmp_kprod[0])
             j_0, j_1, j_2, j_3 = unpackc(tmp_kprod[0])
@@ -542,14 +526,9 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
             jhj[3] += jhwj_33.real
 
     elif corr_mode.literal_value == 2:
-        def impl(lop, rop, w, normf, gain, tmp_kprod, res, jhr, jhj):
-
-            # Compute normalization factor.
-            iunpack(normf, rop)
-            iabsdiv(normf)
+        def impl(lop, rop, w, gain, tmp_kprod, res, jhr, jhj):
 
             # Accumulate an element of jhwr.
-            imul(res, normf)
             v1_imul_v2(res, rop, res)
 
             r_0, r_1 = unpack(res)
@@ -568,21 +547,15 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
             jh_00, jh_11 = unpack(rop)
             j_00, j_11 = unpackc(rop)
             w_00, w_11 = unpack(w)
-            n_00, n_11 = unpack(normf)
 
             # TODO: Consider representing as a vector?
-            jhj[0] += (jh_00*n_00*w_00*n_00*j_00).real
-            jhj[1] += (jh_11*n_11*w_11*n_11*j_11).real
+            jhj[0] += (jh_00*w_00*j_00).real
+            jhj[1] += (jh_11*w_11*j_11).real
 
     elif corr_mode.literal_value == 1:
-        def impl(lop, rop, w, normf, gain, tmp_kprod, res, jhr, jhj):
-
-            # Compute normalization factor.
-            iunpack(normf, rop)
-            iabsdiv(normf)
+        def impl(lop, rop, w, gain, tmp_kprod, res, jhr, jhj):
 
             # Accumulate an element of jhwr.
-            imul(res, normf)
             v1_imul_v2(res, rop, res)
 
             r_0 = unpack(res)
@@ -598,9 +571,8 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
             jh_00 = unpack(rop)
             j_00 = unpackc(rop)
             w_00 = unpack(w)
-            n_00 = unpack(normf)
 
-            jhj[0] += (jh_00*n_00*w_00*n_00*j_00).real
+            jhj[0] += (jh_00*w_00*j_00).real
     else:
         raise ValueError("Unsupported number of correlations.")
 

--- a/quartical/gains/phase/kernel.py
+++ b/quartical/gains/phase/kernel.py
@@ -3,7 +3,7 @@ import numpy as np
 from numba import prange, generated_jit
 from quartical.utils.numba import coerce_literal
 from quartical.gains.general.generics import (solver_intermediaries,
-                                              compute_residual_phase,
+                                              compute_amplocked_residual,
                                               per_array_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
@@ -89,7 +89,7 @@ def phase_solver(base_args, term_args, meta_args, corr_mode):
 
         for loop_idx in range(max_iter):
 
-            compute_residual_phase(base_args,
+            compute_amplocked_residual(base_args,
                                    solver_imdry,
                                    corr_mode)
 

--- a/quartical/gains/tec/kernel.py
+++ b/quartical/gains/tec/kernel.py
@@ -3,7 +3,7 @@ import numpy as np
 from numba import generated_jit
 from quartical.utils.numba import coerce_literal
 from quartical.gains.general.generics import (solver_intermediaries,
-                                              compute_residual_phase,
+                                              compute_amplocked_residual,
                                               per_array_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
@@ -95,7 +95,7 @@ def tec_solver(base_args, term_args, meta_args, corr_mode):
 
         for loop_idx in range(max_iter):
 
-            compute_residual_phase(base_args,
+            compute_amplocked_residual(base_args,
                                    solver_imdry,
                                    corr_mode)
 

--- a/quartical/gains/tec/kernel.py
+++ b/quartical/gains/tec/kernel.py
@@ -96,8 +96,8 @@ def tec_solver(base_args, term_args, meta_args, corr_mode):
         for loop_idx in range(max_iter):
 
             compute_amplocked_residual(base_args,
-                                   solver_imdry,
-                                   corr_mode)
+                                       solver_imdry,
+                                       corr_mode)
 
             compute_jhj_jhr(base_args,
                             term_args,


### PR DESCRIPTION
I realised that I had made the phase-only terms needlessly complicated - there is no need to normalise to unity amplitude. It is sufficient to replace the data amplitudes with the model amplitudes. This is easy to accomplish and can be done entirely in the residual computation. The removes the need for any extra code in the computation of JHJ and JHR. This is particularly beneficial as the normalisation requires computing the absolute values of complex quantities - this is a very expensive operation. The new approach gets away with just a single `sqrt` call which substantially mitigates the previous slowdowns. 

In addition to the above, I have enable nested parallelism in the residual computation (when it is enabled for the solvers). This will help when solving for terms with large solution intervals where the residual has to be computed. 

@landmanbester This may partially address the slowdowns you mentioned. 