### PR TITLE
Fix error in amplocked residual.

### DIFF
--- a/quartical/gains/general/generics.py
+++ b/quartical/gains/general/generics.py
@@ -288,7 +288,8 @@ def compute_amplocked_residual(
 
                         v1_imul_v2(gain_p, v_d, v_d)
                         v1_imul_v2ct(v_d, gain_q, v_d)
-                        iadd(v, v_d)
+
+                    iadd(v, v_d)
 
                 imul_rweight(v, v, row_weights, row_ind)
 


### PR DESCRIPTION
I whitespaced myself - this fixes a major regression I introduced when speeding up phase-only terms. This was missed by the tests as it only affects chains of terms. Simple fix.  