### PR TITLE
Fix regression in phase solvers introduced during optimization pass.

### DIFF
--- a/quartical/gains/crosshand_phase/kernel.py
+++ b/quartical/gains/crosshand_phase/kernel.py
@@ -245,6 +245,8 @@ def compute_jhj_jhr(base_args, term_args, meta_args, solver_imdry, corr_mode):
             lop_qp_arr = valloc(complex_dtype, leading_dims=(n_gdir,))
             rop_qp_arr = valloc(complex_dtype, leading_dims=(n_gdir,))
 
+            norm_factors = valloc(complex_dtype)
+
             tmp_kprod = np.zeros((4, 4), dtype=complex_dtype)
             tmp_jhr = jhr[ti, fi]
             tmp_jhj = jhj[ti, fi]
@@ -332,6 +334,7 @@ def compute_jhj_jhr(base_args, term_args, meta_args, solver_imdry, corr_mode):
                         compute_jhwj_jhwr_elem(lop_pq_d,
                                                rop_pq_d,
                                                w,
+                                               norm_factors,
                                                gains_p[active_term],
                                                tmp_kprod,
                                                r_pq,
@@ -344,6 +347,7 @@ def compute_jhj_jhr(base_args, term_args, meta_args, solver_imdry, corr_mode):
                         compute_jhwj_jhwr_elem(lop_qp_d,
                                                rop_qp_d,
                                                w,
+                                               norm_factors,
                                                gains_q[active_term],
                                                tmp_kprod,
                                                r_qp,
@@ -457,9 +461,16 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
     a_kron_bt = factories.a_kron_bt_factory(corr_mode)
     unpack = factories.unpack_factory(corr_mode)
     unpackc = factories.unpackc_factory(corr_mode)
+    iabsdivsq = factories.iabsdivsq_factory(corr_mode)
+    imul = factories.imul_factory(corr_mode)
 
     if corr_mode.literal_value == 4:
-        def impl(lop, rop, w, gain, tmp_kprod, res, jhr, jhj):
+        def impl(lop, rop, w, normf, gain, tmp_kprod, res, jhr, jhj):
+
+            # Compute normalization factor.
+            v1_imul_v2(lop, rop, normf)
+            iabsdivsq(normf)
+            imul(res, normf)  # Apply normalization factor to r.
 
             # Accumulate an element of jhwr.
             v1_imul_v2(res, rop, res)
@@ -486,6 +497,13 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
             jhr[0] += upd_00
 
             w_0, w_1, w_2, w_3 = unpack(w)  # NOTE: XX, XY, YX, YY
+            n_0, n_1, n_2, n_3 = unpack(normf)
+
+            # Apply normalisation factors by scaling w.
+            w_0 = n_0 * w_0
+            w_1 = n_1 * w_1
+            w_2 = n_2 * w_2
+            w_3 = n_3 * w_3
 
             jh_0, jh_1, jh_2, jh_3 = unpack(tmp_kprod[0])
             j_0, j_1, j_2, j_3 = unpackc(tmp_kprod[0])

--- a/quartical/gains/general/factories.py
+++ b/quartical/gains/general/factories.py
@@ -667,6 +667,56 @@ def iabs_factory(mode):
     return qcjit(impl)
 
 
+def iabsdiv_factory(mode):
+
+    if mode.literal_value == 4:
+        def impl(v1):
+            v1[0] = 0 if v1[0] == 0 else 1/np.abs(v1[0])
+            v1[1] = 0 if v1[1] == 0 else 1/np.abs(v1[1])
+            v1[2] = 0 if v1[2] == 0 else 1/np.abs(v1[2])
+            v1[3] = 0 if v1[3] == 0 else 1/np.abs(v1[3])
+    elif mode.literal_value == 2:
+        def impl(v1):
+            v1[0] = 0 if v1[0] == 0 else 1/np.abs(v1[0])
+            v1[1] = 0 if v1[1] == 0 else 1/np.abs(v1[1])
+    elif mode.literal_value == 1:
+        def impl(v1):
+            v1[0] = 0 if v1[0] == 0 else 1/np.abs(v1[0])
+    else:
+        raise ValueError("Unsupported number of correlations.")
+
+    return qcjit(impl)
+
+
+def iabsdivsq_factory(mode):
+
+    unpack = unpack_factory(mode)
+
+    if mode.literal_value == 4:
+        def impl(v1):
+            v1_0, v1_1, v1_2, v1_3 = unpack(v1)
+
+            v1[0] = 0 if v1_0 == 0 else 1/(v1_0.real**2 + v1_0.imag**2)
+            v1[1] = 0 if v1_1 == 0 else 1/(v1_1.real**2 + v1_1.imag**2)
+            v1[2] = 0 if v1_2 == 0 else 1/(v1_2.real**2 + v1_2.imag**2)
+            v1[3] = 0 if v1_3 == 0 else 1/(v1_3.real**2 + v1_3.imag**2)
+    elif mode.literal_value == 2:
+        def impl(v1):
+            v1_0, v1_1 = unpack(v1)
+
+            v1[0] = 0 if v1_0 == 0 else 1/(v1_0.real**2 + v1_0.imag**2)
+            v1[1] = 0 if v1_1 == 0 else 1/(v1_1.real**2 + v1_1.imag**2)
+    elif mode.literal_value == 1:
+        def impl(v1):
+            v1_0 = unpack(v1)
+
+            v1[0] = 0 if v1_0 == 0 else 1/(v1_0.real**2 + v1_0.imag**2)
+    else:
+        raise ValueError("Unsupported number of correlations.")
+
+    return qcjit(impl)
+
+
 def v1_idiv_absv2_factory(mode):
 
     if mode.literal_value == 4:


### PR DESCRIPTION
As it says on the label, I made a mistake when optimizing the phase-only terms. This was due to a conceptual error on my part but this mistake has ultimately proved to be beneficial - I now have a better grasp of the phase/amp-only problems.  