### PR TITLE
Robflag

### DIFF
--- a/quartical/calibration/solver.py
+++ b/quartical/calibration/solver.py
@@ -150,11 +150,13 @@ def solver_wrapper(term_spec_list, solver_opts, chain_opts, **kwargs):
                     etas,
                     icovariance,
                     dof,
+                    solver_opts.weight_flag_threshold,
                     kwargs["corr_mode"])
 
                 # propagate robust flags
-                fsel = etas == 0
-                results_dict["flags"][fsel] = 1
+                if solver_opts.propagate_flags:
+                    fsel = etas == 0
+                    results_dict["flags"][fsel] = 1
 
         # TODO: Ugly hack for larger jhj matrices. Refine.
         if jhj.ndim == 6:

--- a/quartical/calibration/solver.py
+++ b/quartical/calibration/solver.py
@@ -152,6 +152,10 @@ def solver_wrapper(term_spec_list, solver_opts, chain_opts, **kwargs):
                     dof,
                     kwargs["corr_mode"])
 
+                # propagate robust flags
+                fsel = etas == 0
+                results_dict["flags"][fsel] = 1
+
         # TODO: Ugly hack for larger jhj matrices. Refine.
         if jhj.ndim == 6:
             jhj = jhj[:, :, :, :, range(jhj.shape[-2]), range(jhj.shape[-1])]
@@ -159,10 +163,6 @@ def solver_wrapper(term_spec_list, solver_opts, chain_opts, **kwargs):
         results_dict[f"{term_name}-conviter"] += np.atleast_2d(info_tup[0])
         results_dict[f"{term_name}-convperc"] = np.atleast_2d(info_tup[1])
         results_dict[f"{term_name}-jhj"] = jhj
-        # propagate robust flags
-        if solver_opts.robust:
-            fsel = etas == 0
-            results_dict["flags"][fsel] = True
 
     gc.collect()
 

--- a/quartical/calibration/solver.py
+++ b/quartical/calibration/solver.py
@@ -96,7 +96,7 @@ def solver_wrapper(term_spec_list, solver_opts, chain_opts, **kwargs):
 
     if solver_opts.robust:
         final_epoch = len(iter_recipe) // len(terms)
-        etas = np.zeros_like(kwargs["weights"][..., 0])
+        etas = np.ones_like(kwargs["weights"][..., 0])
         icovariance = np.zeros(kwargs["corr_mode"], np.float64)
         dof = 5
 
@@ -159,6 +159,10 @@ def solver_wrapper(term_spec_list, solver_opts, chain_opts, **kwargs):
         results_dict[f"{term_name}-conviter"] += np.atleast_2d(info_tup[0])
         results_dict[f"{term_name}-convperc"] = np.atleast_2d(info_tup[1])
         results_dict[f"{term_name}-jhj"] = jhj
+        # propagate robust flags
+        if solver_opts.robust:
+            fsel = etas == 0
+            results_dict["flags"][fsel] = True
 
     gc.collect()
 

--- a/quartical/calibration/solver.py
+++ b/quartical/calibration/solver.py
@@ -150,11 +150,11 @@ def solver_wrapper(term_spec_list, solver_opts, chain_opts, **kwargs):
                     etas,
                     icovariance,
                     dof,
-                    solver_opts.weight_flag_threshold,
+                    solver_opts.reweighting_flag_threshold,
                     kwargs["corr_mode"])
 
                 # propagate robust flags
-                if solver_opts.propagate_flags:
+                if solver_opts.reweighting_flag_threshold:
                     fsel = etas == 0
                     results_dict["flags"][fsel] = 1
 

--- a/quartical/config/argument_schema.yaml
+++ b/quartical/config/argument_schema.yaml
@@ -306,6 +306,14 @@ solver:
         the solver.iter_recipe loops through the chain multiple times. The
         reweighting step only happens once per traversal of the chain.
 
+    weight_flag_threshold:
+      dtype: float
+      default: 0.0
+      info:
+        Flag a data point if it's weight changes by this fraction during
+        robust reweighting i.e. if updated_weight/original_weight is less
+        than the weight_flag_threshold a data point get's flagged.
+
     threads:
       dtype: int
       default: 1

--- a/quartical/config/argument_schema.yaml
+++ b/quartical/config/argument_schema.yaml
@@ -306,13 +306,13 @@ solver:
         the solver.iter_recipe loops through the chain multiple times. The
         reweighting step only happens once per traversal of the chain.
 
-    weight_flag_threshold:
+    reweighting_flag_threshold:
       dtype: float
       default: 0.0
       info:
         Flag a data point if it's weight changes by this fraction during
         robust reweighting i.e. if updated_weight/original_weight is less
-        than the weight_flag_threshold a data point get's flagged.
+        than the reweighting_flag_threshold a data point get's flagged.
 
     threads:
       dtype: int

--- a/quartical/config/external.py
+++ b/quartical/config/external.py
@@ -176,12 +176,12 @@ def make_stimela_schema(params: Dict[str, Any],
 
     inputs = inputs.copy()
 
-    terms = params.get('solver/terms', None)
+    terms = params.get('solver.terms', None)
     if terms is None:
         terms = _config_dataclasses["solver"]().terms
 
     for jones in terms:
         for key, value in _gain_schema.items():
-            inputs[f"{jones}/{key}"] = value
+            inputs[f"{jones}.{key}"] = value
 
     return inputs, outputs

--- a/quartical/stimela_cabs.yaml
+++ b/quartical/stimela_cabs.yaml
@@ -3,12 +3,8 @@ cabs:
     command: goquartical
     policies:
       key_value: true
-      replace:
-        '/': '.'
     inputs:
       _include: (quartical.config)argument_schema.yaml
-      _flatten: 1
-      _flatten_sep: /
     dynamic_schema: quartical.config.external.make_stimela_schema
 
   qcalbackup:

--- a/quartical/weights/robust.py
+++ b/quartical/weights/robust.py
@@ -99,7 +99,7 @@ def update_etas(residuals, flags, etas, icovariance, dof, flag_threshold,
                     denominator = dof + update_etas_inner(residuals[r, f],
                                                           icovariance)
                     etan = numerator/denominator
-                    if etas[r, f] != 0  and etan/etas[r, f]  < flag_threshold:
+                    if etas[r, f] != 0 and etan/etas[r, f] < flag_threshold:
                         etas[r, f] = 0
                     else:
                         etas[r, f] = etan

--- a/quartical/weights/robust.py
+++ b/quartical/weights/robust.py
@@ -96,7 +96,11 @@ def update_etas(residuals, flags, etas, icovariance, dof, mode):
                     numerator = dof + n_corr  # Not correct for diagonal terms.
                     denominator = dof + update_etas_inner(residuals[r, f],
                                                           icovariance)
-                    etas[r, f] = numerator/denominator
+                    etan = numerator/denominator
+                    if etas[r, f] != 0  and etan/etas[r, f]  < 0.2:
+                        etas[r, f] = 0
+                    else:
+                        etas[r, f] = etan
 
     return impl
 

--- a/quartical/weights/robust.py
+++ b/quartical/weights/robust.py
@@ -85,7 +85,8 @@ def update_etas(residuals, flags, etas, icovariance, dof, flag_threshold,
 
     update_etas_inner = update_etas_inner_factory(mode)
 
-    def impl(residuals, flags, etas, icovariance, dof, mode):
+    def impl(residuals, flags, etas, icovariance, dof, flag_threshold,
+             mode):
 
         n_row, n_chan, n_corr = residuals.shape
 

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,7 @@ requirements = [
     "bokeh",
     "xarray>=0.20.0",
     "rich",
-    "scabha"
-    "@git+https://github.com/caracal-pipeline/scabha2"
-    "@rich",
+    "scabha",
 ]
 
 setup(


### PR DESCRIPTION
Add option to flag data based on how much the weight changes during robust reweighting. This is not controlled by a single parameter viz. solver.weight_flag_threshold. By default it is set to zero maintaining the current behaviour. Flags will only propagated to the output if solver.propagate_flags is also set