### PR TITLE
Arbitrary internal parallelism

### DIFF
--- a/quartical/calibration/solver.py
+++ b/quartical/calibration/solver.py
@@ -15,6 +15,7 @@ meta_args_nt = namedtuple(
         "active_term",
         "stop_frac",
         "stop_crit",
+        "threads",
         "dd_term",
         "solve_per",
         "robust"
@@ -122,6 +123,7 @@ def solver_wrapper(term_spec_list, solver_opts, chain_opts, **kwargs):
                                  active_term,
                                  solver_opts.convergence_fraction,
                                  solver_opts.convergence_criteria,
+                                 solver_opts.threads,
                                  term_opts.direction_dependent,
                                  term_opts.solve_per,
                                  robust)

--- a/quartical/gains/amplitude/kernel.py
+++ b/quartical/gains/amplitude/kernel.py
@@ -2,16 +2,18 @@
 import numpy as np
 from numba import prange, generated_jit
 from quartical.utils.numba import coerce_literal
-from quartical.gains.general.generics import (solver_intermediaries,
-                                              per_array_jhj_jhr)
+from quartical.gains.general.generics import (native_intermediaries,
+                                              upsampled_itermediaries,
+                                              per_array_jhj_jhr,
+                                              resample_solints,
+                                              downsample_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
                                               apply_gain_flags,
                                               update_param_flags)
 from quartical.gains.general.convenience import (get_row,
-                                                 get_chan_extents,
-                                                 get_row_extents)
+                                                 get_extents)
 import quartical.gains.general.factories as factories
 from quartical.gains.general.inversion import (invert_factory,
                                                inversion_buffer_factory)
@@ -65,44 +67,66 @@ def amplitude_solver(base_args, term_args, meta_args, corr_mode):
         max_iter = meta_args.iters
         solve_per = meta_args.solve_per
         dd_term = meta_args.dd_term
+        n_thread = meta_args.threads
 
         active_gain = gains[active_term]
         active_gain_flags = gain_flags[active_term]
         active_params = term_args.params[active_term]
 
-        # Set up some intemediaries used for flagging. TODO: Move?
+        # Set up some intemediaries used for flagging
         km1_gain = active_gain.copy()
         km1_abs2_diffs = np.zeros_like(active_gain_flags, dtype=np.float64)
         abs2_diffs_trend = np.zeros_like(active_gain_flags, dtype=np.float64)
         flag_imdry = \
             flag_intermediaries(km1_gain, km1_abs2_diffs, abs2_diffs_trend)
 
-        # Set up some intemediaries used for solving. TODO: Move?
+        # Set up some intemediaries used for solving.
         real_dtype = active_gain.real.dtype
-        pshape = active_params.shape
-        jhj = np.empty(pshape + (pshape[-1],), dtype=real_dtype)
-        jhr = np.empty(pshape, dtype=real_dtype)
-        update = np.zeros_like(jhr)
-        solver_imdry = solver_intermediaries(jhj, jhr, update)
+        param_shape = active_params.shape
+
+        active_t_map_g = base_args.t_map_arr[0, :, active_term]
+        active_f_map_g = base_args.f_map_arr[0, :, active_term]
+
+        # Create more work to do in paralllel when needed, else no-op.
+        resampler = resample_solints(active_t_map_g, param_shape, n_thread)
+
+        # Determine the starts and stops of the rows and channels associated
+        # with each solution interval.
+        extents = get_extents(resampler.upsample_t_map, active_f_map_g)
+
+        upsample_shape = resampler.upsample_shape
+        upsampled_jhj = np.empty(upsample_shape + (upsample_shape[-1],),
+                                 dtype=real_dtype)
+        upsampled_jhr = np.empty(upsample_shape, dtype=real_dtype)
+        jhj = upsampled_jhj[:param_shape[0]]
+        jhr = upsampled_jhr[:param_shape[0]]
+        update = np.zeros(param_shape, dtype=real_dtype)
+
+        upsampled_imdry = upsampled_itermediaries(upsampled_jhj, upsampled_jhr)
+        native_imdry = native_intermediaries(jhj, jhr, update)
 
         for loop_idx in range(max_iter):
 
             compute_jhj_jhr(base_args,
                             term_args,
                             meta_args,
-                            solver_imdry,
+                            upsampled_imdry,
+                            extents,
                             corr_mode)
 
-            if solve_per == "array":
-                per_array_jhj_jhr(solver_imdry)
+            if resampler.active:
+                downsample_jhj_jhr(upsampled_imdry, resampler.downsample_t_map)
 
-            compute_update(solver_imdry,
+            if solve_per == "array":
+                per_array_jhj_jhr(native_imdry)
+
+            compute_update(native_imdry,
                            corr_mode)
 
             finalize_update(base_args,
                             term_args,
                             meta_args,
-                            solver_imdry,
+                            native_imdry,
                             loop_idx,
                             corr_mode)
 
@@ -137,7 +161,7 @@ def amplitude_solver(base_args, term_args, meta_args, corr_mode):
             apply_gain_flags(base_args,
                              meta_args)
 
-        return jhj, term_conv_info(loop_idx + 1, conv_perc)
+        return native_imdry.jhj, term_conv_info(loop_idx + 1, conv_perc)
 
     return impl
 
@@ -151,7 +175,8 @@ def compute_jhj_jhr(
     base_args,
     term_args,
     meta_args,
-    solver_imdry,
+    upsampled_imdry,
+    extents,
     corr_mode
 ):
 
@@ -177,7 +202,8 @@ def compute_jhj_jhr(
         base_args,
         term_args,
         meta_args,
-        solver_imdry,
+        upsampled_imdry,
+        extents,
         corr_mode
     ):
 
@@ -197,8 +223,8 @@ def compute_jhj_jhr(
         f_map_arr = base_args.f_map_arr[0]  # We only need the gain mappings.
         d_map_arr = base_args.d_map_arr
 
-        jhj = solver_imdry.jhj
-        jhr = solver_imdry.jhr
+        jhj = upsampled_imdry.jhj
+        jhr = upsampled_imdry.jhr
 
         _, n_chan, n_dir, n_corr = model.shape
 
@@ -213,16 +239,10 @@ def compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        # Determine the starts and stops of the rows and channels associated
-        # with each solution interval. This could even be moved out for speed.
-        row_starts, row_stops = get_row_extents(t_map_arr,
-                                                active_term,
-                                                n_tint)
-
-        chan_starts, chan_stops = get_chan_extents(f_map_arr,
-                                                   active_term,
-                                                   n_fint,
-                                                   n_chan)
+        row_starts = extents.row_starts
+        row_stops = extents.row_stops
+        chan_starts = extents.chan_starts
+        chan_stops = extents.chan_stops
 
         # Determine loop variables based on where we are in the chain.
         # gt means greater than (n>j) and lt means less than (n<j).
@@ -377,20 +397,20 @@ def compute_jhj_jhr(
                parallel=True,
                cache=True,
                nogil=True)
-def compute_update(solver_imdry, corr_mode):
+def compute_update(native_imdry, corr_mode):
 
     # We want to dispatch based on this field so we need its type.
-    jhj = solver_imdry[solver_imdry.fields.index('jhj')]
+    jhj = native_imdry[native_imdry.fields.index('jhj')]
 
     generalised = jhj.ndim == 6
     inversion_buffer = inversion_buffer_factory(generalised=generalised)
     invert = invert_factory(corr_mode, generalised=generalised)
 
-    def impl(solver_imdry, corr_mode):
+    def impl(native_imdry, corr_mode):
 
-        jhj = solver_imdry.jhj
-        jhr = solver_imdry.jhr
-        update = solver_imdry.update
+        jhj = native_imdry.jhj
+        jhr = native_imdry.jhr
+        update = native_imdry.update
 
         n_tint, n_fint, n_ant, n_dir, n_param = jhr.shape
 
@@ -418,13 +438,13 @@ def compute_update(solver_imdry, corr_mode):
 
 @generated_jit(nopython=True, fastmath=True, parallel=False, cache=True,
                nogil=True)
-def finalize_update(base_args, term_args, meta_args, solver_imdry, loop_idx,
+def finalize_update(base_args, term_args, meta_args, native_imdry, loop_idx,
                     corr_mode):
 
     set_identity = factories.set_identity_factory(corr_mode)
     param_to_gain = param_to_gain_factory(corr_mode)
 
-    def impl(base_args, term_args, meta_args, solver_imdry, loop_idx,
+    def impl(base_args, term_args, meta_args, native_imdry, loop_idx,
              corr_mode):
 
         active_term = meta_args.active_term
@@ -434,7 +454,7 @@ def finalize_update(base_args, term_args, meta_args, solver_imdry, loop_idx,
 
         params = term_args.params[active_term]
 
-        update = solver_imdry.update
+        update = native_imdry.update
 
         n_tint, n_fint, n_ant, n_dir, n_corr = gain.shape
 

--- a/quartical/gains/complex/kernel.py
+++ b/quartical/gains/complex/kernel.py
@@ -2,15 +2,17 @@
 import numpy as np
 from numba import prange, generated_jit
 from quartical.utils.numba import coerce_literal
-from quartical.gains.general.generics import (solver_intermediaries,
-                                              per_array_jhj_jhr)
+from quartical.gains.general.generics import (native_intermediaries,
+                                              upsampled_itermediaries,
+                                              per_array_jhj_jhr,
+                                              resample_solints,
+                                              downsample_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
                                               apply_gain_flags)
 from quartical.gains.general.convenience import (get_row,
-                                                 get_chan_extents,
-                                                 get_row_extents)
+                                                 get_extents)
 import quartical.gains.general.factories as factories
 from quartical.gains.general.inversion import (invert_factory,
                                                inversion_buffer_factory)
@@ -47,6 +49,7 @@ def complex_solver(base_args, term_args, meta_args, corr_mode):
         max_iter = meta_args.iters
         solve_per = meta_args.solve_per
         dd_term = meta_args.dd_term
+        n_thread = meta_args.threads
 
         active_gain = gains[active_term]
         active_gain_flags = gain_flags[active_term]
@@ -58,30 +61,53 @@ def complex_solver(base_args, term_args, meta_args, corr_mode):
         flag_imdry = \
             flag_intermediaries(km1_gain, km1_abs2_diffs, abs2_diffs_trend)
 
-        # Set up some intemediaries used for solving. TODO: Move?
-        jhj = np.empty(get_jhj_dims(active_gain), dtype=active_gain.dtype)
-        jhr = np.empty_like(active_gain)
-        update = np.zeros_like(active_gain)
-        solver_imdry = solver_intermediaries(jhj, jhr, update)
+        # Set up some intemediaries used for solving.
+        complex_dtype = active_gain.dtype
+        gain_shape = active_gain.shape
+
+        active_t_map_g = base_args.t_map_arr[0, :, active_term]
+        active_f_map_g = base_args.f_map_arr[0, :, active_term]
+
+        # Create more work to do in paralllel when needed, else no-op.
+        resampler = resample_solints(active_t_map_g, gain_shape, n_thread)
+
+        # Determine the starts and stops of the rows and channels associated
+        # with each solution interval.
+        extents = get_extents(resampler.upsample_t_map, active_f_map_g)
+
+        upsample_shape = resampler.upsample_shape
+        upsampled_jhj = np.empty(get_jhj_dims(upsample_shape),
+                                 dtype=complex_dtype)
+        upsampled_jhr = np.empty(upsample_shape, dtype=complex_dtype)
+        jhj = upsampled_jhj[:gain_shape[0]]
+        jhr = upsampled_jhr[:gain_shape[0]]
+        update = np.zeros(gain_shape, dtype=complex_dtype)
+
+        upsampled_imdry = upsampled_itermediaries(upsampled_jhj, upsampled_jhr)
+        native_imdry = native_intermediaries(jhj, jhr, update)
 
         for loop_idx in range(max_iter):
 
             compute_jhj_jhr(base_args,
                             term_args,
                             meta_args,
-                            solver_imdry,
+                            upsampled_imdry,
+                            extents,
                             corr_mode)
 
-            if solve_per == "array":
-                per_array_jhj_jhr(solver_imdry)
+            if resampler.active:
+                downsample_jhj_jhr(upsampled_imdry, resampler.downsample_t_map)
 
-            compute_update(solver_imdry,
+            if solve_per == "array":
+                per_array_jhj_jhr(native_imdry)
+
+            compute_update(native_imdry,
                            corr_mode)
 
             finalize_update(base_args,
                             term_args,
                             meta_args,
-                            solver_imdry,
+                            native_imdry,
                             loop_idx,
                             corr_mode)
 
@@ -110,7 +136,7 @@ def complex_solver(base_args, term_args, meta_args, corr_mode):
             apply_gain_flags(base_args,
                              meta_args)
 
-        return jhj, term_conv_info(loop_idx + 1, conv_perc)
+        return native_imdry.jhj, term_conv_info(loop_idx + 1, conv_perc)
 
     return impl
 
@@ -124,7 +150,8 @@ def compute_jhj_jhr(
     base_args,
     term_args,
     meta_args,
-    solver_imdry,
+    upsampled_imdry,
+    extents,
     corr_mode
 ):
 
@@ -149,7 +176,8 @@ def compute_jhj_jhr(
         base_args,
         term_args,
         meta_args,
-        solver_imdry,
+        upsampled_imdry,
+        extents,
         corr_mode
     ):
 
@@ -169,8 +197,8 @@ def compute_jhj_jhr(
         f_map_arr = base_args.f_map_arr[0]  # We only need the gain mappings.
         d_map_arr = base_args.d_map_arr
 
-        jhj = solver_imdry.jhj
-        jhr = solver_imdry.jhr
+        jhj = upsampled_imdry.jhj
+        jhr = upsampled_imdry.jhr
 
         _, n_chan, n_dir, n_corr = model.shape
 
@@ -185,16 +213,10 @@ def compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        # Determine the starts and stops of the rows and channels associated
-        # with each solution interval. This could even be moved out for speed.
-        row_starts, row_stops = get_row_extents(t_map_arr,
-                                                active_term,
-                                                n_tint)
-
-        chan_starts, chan_stops = get_chan_extents(f_map_arr,
-                                                   active_term,
-                                                   n_fint,
-                                                   n_chan)
+        row_starts = extents.row_starts
+        row_stops = extents.row_stops
+        chan_starts = extents.chan_starts
+        chan_stops = extents.chan_stops
 
         # Determine loop variables based on where we are in the chain.
         # gt means greater than (n>j) and lt means less than (n<j).
@@ -350,20 +372,20 @@ def compute_jhj_jhr(
                parallel=True,
                cache=True,
                nogil=True)
-def compute_update(solver_imdry, corr_mode):
+def compute_update(native_imdry, corr_mode):
 
     # We want to dispatch based on this field so we need its type.
-    jhj = solver_imdry[solver_imdry.fields.index('jhj')]
+    jhj = native_imdry[native_imdry.fields.index('jhj')]
 
     generalised = jhj.ndim == 6
     inversion_buffer = inversion_buffer_factory(generalised=generalised)
     invert = invert_factory(corr_mode, generalised=generalised)
 
-    def impl(solver_imdry, corr_mode):
+    def impl(native_imdry, corr_mode):
 
-        jhj = solver_imdry.jhj
-        jhr = solver_imdry.jhr
-        update = solver_imdry.update
+        jhj = native_imdry.jhj
+        jhr = native_imdry.jhr
+        update = native_imdry.update
 
         n_tint, n_fint, n_ant, n_dir, n_param = jhr.shape
 
@@ -391,12 +413,12 @@ def compute_update(solver_imdry, corr_mode):
 
 @generated_jit(nopython=True, fastmath=True, parallel=False, cache=True,
                nogil=True)
-def finalize_update(base_args, term_args, meta_args, solver_imdry, loop_idx,
+def finalize_update(base_args, term_args, meta_args, native_imdry, loop_idx,
                     corr_mode):
 
     set_identity = factories.set_identity_factory(corr_mode)
 
-    def impl(base_args, term_args, meta_args, solver_imdry, loop_idx,
+    def impl(base_args, term_args, meta_args, native_imdry, loop_idx,
              corr_mode):
 
         dd_term = meta_args.dd_term
@@ -405,7 +427,7 @@ def finalize_update(base_args, term_args, meta_args, solver_imdry, loop_idx,
         gain = base_args.gains[active_term]
         gain_flags = base_args.gain_flags[active_term]
 
-        update = solver_imdry.update
+        update = native_imdry.update
 
         n_tint, n_fint, n_ant, n_dir, n_corr = gain.shape
 
@@ -510,11 +532,11 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
 def get_jhj_dims_factory(corr_mode):
 
     if corr_mode.literal_value == 4:
-        def impl(gain):
-            return gain.shape[:4] + (4, 4)
+        def impl(shape):
+            return shape[:4] + (4, 4)
     elif corr_mode.literal_value in (1, 2):
-        def impl(gain):
-            return gain.shape
+        def impl(shape):
+            return shape
     else:
         raise ValueError("Unsupported number of correlations.")
 

--- a/quartical/gains/crosshand_phase/kernel.py
+++ b/quartical/gains/crosshand_phase/kernel.py
@@ -82,14 +82,14 @@ def crosshand_phase_solver(base_args, term_args, meta_args, corr_mode):
         param_shape = active_params.shape
 
         active_t_map_g = base_args.t_map_arr[0, :, active_term]
-        active_f_map_p = base_args.f_map_arr[1, :, active_term]
+        active_f_map_g = base_args.f_map_arr[0, :, active_term]
 
         # Create more work to do in paralllel when needed, else no-op.
         resampler = resample_solints(active_t_map_g, param_shape, n_thread)
 
         # Determine the starts and stops of the rows and channels associated
         # with each solution interval.
-        extents = get_extents(resampler.upsample_t_map, active_f_map_p)
+        extents = get_extents(resampler.upsample_t_map, active_f_map_g)
 
         upsample_shape = resampler.upsample_shape
         upsampled_jhj = np.empty(upsample_shape + (upsample_shape[-1],),

--- a/quartical/gains/crosshand_phase/kernel.py
+++ b/quartical/gains/crosshand_phase/kernel.py
@@ -2,21 +2,22 @@
 import numpy as np
 from numba import prange, generated_jit
 from quartical.utils.numba import coerce_literal
-from quartical.gains.general.generics import (solver_intermediaries,
-                                              per_array_jhj_jhr)
+from quartical.gains.general.generics import (native_intermediaries,
+                                              upsampled_itermediaries,
+                                              per_array_jhj_jhr,
+                                              resample_solints,
+                                              downsample_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
                                               apply_gain_flags,
                                               update_param_flags)
 from quartical.gains.general.convenience import (get_row,
-                                                 get_chan_extents,
-                                                 get_row_extents)
+                                                 get_extents)
 import quartical.gains.general.factories as factories
 from quartical.gains.general.inversion import (invert_factory,
                                                inversion_buffer_factory)
 from collections import namedtuple
-
 
 # This can be done without a named tuple now. TODO: Add unpacking to
 # constructor.
@@ -63,44 +64,66 @@ def crosshand_phase_solver(base_args, term_args, meta_args, corr_mode):
         max_iter = meta_args.iters
         solve_per = meta_args.solve_per
         dd_term = meta_args.dd_term
+        n_thread = meta_args.threads
 
         active_gain = gains[active_term]
         active_gain_flags = gain_flags[active_term]
         active_params = term_args.params[active_term]
 
-        # Set up some intemediaries used for flagging. TODO: Move?
+        # Set up some intemediaries used for flagging.
         km1_gain = active_gain.copy()
         km1_abs2_diffs = np.zeros_like(active_gain_flags, dtype=np.float64)
         abs2_diffs_trend = np.zeros_like(active_gain_flags, dtype=np.float64)
         flag_imdry = \
             flag_intermediaries(km1_gain, km1_abs2_diffs, abs2_diffs_trend)
 
-        # Set up some intemediaries used for solving. TODO: Move?
+        # Set up some intemediaries used for solving.
         real_dtype = active_gain.real.dtype
-        pshape = active_params.shape
-        jhj = np.empty(pshape + (pshape[-1],), dtype=real_dtype)
-        jhr = np.empty(pshape, dtype=real_dtype)
-        update = np.zeros_like(jhr)
-        solver_imdry = solver_intermediaries(jhj, jhr, update)
+        param_shape = active_params.shape
+
+        active_t_map_g = base_args.t_map_arr[0, :, active_term]
+        active_f_map_p = base_args.f_map_arr[1, :, active_term]
+
+        # Create more work to do in paralllel when needed, else no-op.
+        resampler = resample_solints(active_t_map_g, param_shape, n_thread)
+
+        # Determine the starts and stops of the rows and channels associated
+        # with each solution interval.
+        extents = get_extents(resampler.upsample_t_map, active_f_map_p)
+
+        upsample_shape = resampler.upsample_shape
+        upsampled_jhj = np.empty(upsample_shape + (upsample_shape[-1],),
+                                 dtype=real_dtype)
+        upsampled_jhr = np.empty(upsample_shape, dtype=real_dtype)
+        jhj = upsampled_jhj[:param_shape[0]]
+        jhr = upsampled_jhr[:param_shape[0]]
+        update = np.zeros(param_shape, dtype=real_dtype)
+
+        upsampled_imdry = upsampled_itermediaries(upsampled_jhj, upsampled_jhr)
+        native_imdry = native_intermediaries(jhj, jhr, update)
 
         for loop_idx in range(max_iter):
 
             compute_jhj_jhr(base_args,
                             term_args,
                             meta_args,
-                            solver_imdry,
+                            upsampled_imdry,
+                            extents,
                             corr_mode)
 
-            if solve_per == "array":
-                per_array_jhj_jhr(solver_imdry)
+            if resampler.active:
+                downsample_jhj_jhr(upsampled_imdry, resampler.downsample_t_map)
 
-            compute_update(solver_imdry,
+            if solve_per == "array":
+                per_array_jhj_jhr(native_imdry)
+
+            compute_update(native_imdry,
                            corr_mode)
 
             finalize_update(base_args,
                             term_args,
                             meta_args,
-                            solver_imdry,
+                            native_imdry,
                             loop_idx,
                             corr_mode)
 
@@ -136,7 +159,7 @@ def crosshand_phase_solver(base_args, term_args, meta_args, corr_mode):
             apply_gain_flags(base_args,
                              meta_args)
 
-        return jhj, term_conv_info(loop_idx + 1, conv_perc)
+        return native_imdry.jhj, term_conv_info(loop_idx + 1, conv_perc)
 
     return impl
 
@@ -150,7 +173,8 @@ def compute_jhj_jhr(
     base_args,
     term_args,
     meta_args,
-    solver_imdry,
+    upsampled_imdry,
+    extents,
     corr_mode
 ):
 
@@ -176,7 +200,8 @@ def compute_jhj_jhr(
         base_args,
         term_args,
         meta_args,
-        solver_imdry,
+        upsampled_imdry,
+        extents,
         corr_mode
     ):
 
@@ -196,8 +221,8 @@ def compute_jhj_jhr(
         f_map_arr = base_args.f_map_arr[0]  # We only need the gain mappings.
         d_map_arr = base_args.d_map_arr
 
-        jhj = solver_imdry.jhj
-        jhr = solver_imdry.jhr
+        jhj = upsampled_imdry.jhj
+        jhr = upsampled_imdry.jhr
 
         _, n_chan, n_dir, n_corr = model.shape
 
@@ -212,16 +237,10 @@ def compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        # Determine the starts and stops of the rows and channels associated
-        # with each solution interval. This could even be moved out for speed.
-        row_starts, row_stops = get_row_extents(t_map_arr,
-                                                active_term,
-                                                n_tint)
-
-        chan_starts, chan_stops = get_chan_extents(f_map_arr,
-                                                   active_term,
-                                                   n_fint,
-                                                   n_chan)
+        row_starts = extents.row_starts
+        row_stops = extents.row_stops
+        chan_starts = extents.chan_starts
+        chan_stops = extents.chan_stops
 
         # Determine loop variables based on where we are in the chain.
         # gt means greater than (n>j) and lt means less than (n<j).
@@ -382,20 +401,20 @@ def compute_jhj_jhr(
                parallel=True,
                cache=True,
                nogil=True)
-def compute_update(solver_imdry, corr_mode):
+def compute_update(native_imdry, corr_mode):
 
     # We want to dispatch based on this field so we need its type.
-    jhj = solver_imdry[solver_imdry.fields.index('jhj')]
+    jhj = native_imdry[native_imdry.fields.index('jhj')]
 
     generalised = jhj.ndim == 6
     inversion_buffer = inversion_buffer_factory(generalised=generalised)
     invert = invert_factory(corr_mode, generalised=generalised)
 
-    def impl(solver_imdry, corr_mode):
+    def impl(native_imdry, corr_mode):
 
-        jhj = solver_imdry.jhj
-        jhr = solver_imdry.jhr
-        update = solver_imdry.update
+        jhj = native_imdry.jhj
+        jhr = native_imdry.jhr
+        update = native_imdry.update
 
         n_tint, n_fint, n_ant, n_dir, n_param = jhr.shape
 
@@ -423,13 +442,13 @@ def compute_update(solver_imdry, corr_mode):
 
 @generated_jit(nopython=True, fastmath=True, parallel=False, cache=True,
                nogil=True)
-def finalize_update(base_args, term_args, meta_args, solver_imdry, loop_idx,
+def finalize_update(base_args, term_args, meta_args, native_imdry, loop_idx,
                     corr_mode):
 
     set_identity = factories.set_identity_factory(corr_mode)
     param_to_gain = param_to_gain_factory(corr_mode)
 
-    def impl(base_args, term_args, meta_args, solver_imdry, loop_idx,
+    def impl(base_args, term_args, meta_args, native_imdry, loop_idx,
              corr_mode):
 
         active_term = meta_args.active_term
@@ -439,7 +458,7 @@ def finalize_update(base_args, term_args, meta_args, solver_imdry, loop_idx,
 
         params = term_args.params[active_term]
 
-        update = solver_imdry.update
+        update = native_imdry.update
 
         n_tint, n_fint, n_ant, n_dir, n_corr = gain.shape
 

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -13,9 +13,7 @@ from quartical.gains.general.flagging import (flag_intermediaries,
                                               apply_gain_flags,
                                               update_param_flags)
 from quartical.gains.general.convenience import (get_row,
-                                                 get_chan_extents,
-                                                 get_row_extents,
-                                                 extent_tuple)
+                                                 get_extents)
 import quartical.gains.general.factories as factories
 from quartical.gains.general.inversion import (invert_factory,
                                                inversion_buffer_factory)
@@ -100,15 +98,7 @@ def delay_solver(base_args, term_args, meta_args, corr_mode):
 
         # Determine the starts and stops of the rows and channels associated
         # with each solution interval.
-        row_starts, row_stops = get_row_extents(upsample_t_map)
-        chan_starts, chan_stops = get_chan_extents(active_f_map_p)
-
-        extents = extent_tuple(
-            row_starts,
-            row_stops,
-            chan_starts,
-            chan_stops
-        )
+        extents = get_extents(upsample_t_map, active_f_map_p)
 
         jhj = np.empty(upsample_shape + (upsample_shape[-1],),
                        dtype=real_dtype)

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -74,14 +74,14 @@ def delay_solver(base_args, term_args, meta_args, corr_mode):
         active_gain_flags = gain_flags[active_term]
         active_params = term_args.params[active_term]
 
-        # Set up some intemediaries used for flagging. TODO: Move?
+        # Set up some intemediaries used for flagging.
         km1_gain = active_gain.copy()
         km1_abs2_diffs = np.zeros_like(active_gain_flags, dtype=np.float64)
         abs2_diffs_trend = np.zeros_like(active_gain_flags, dtype=np.float64)
         flag_imdry = \
             flag_intermediaries(km1_gain, km1_abs2_diffs, abs2_diffs_trend)
 
-        # Set up some intemediaries used for solving. TODO: Move?
+        # Set up some intemediaries used for solving.
         real_dtype = active_gain.real.dtype
         param_shape = active_params.shape
 
@@ -122,7 +122,7 @@ def delay_solver(base_args, term_args, meta_args, corr_mode):
                             scaled_cf,
                             corr_mode)
 
-            if upsample_shape != param_shape:
+            if resampler.active:
                 downsample_jhj_jhr(upsampled_imdry, resampler.downsample_t_map)
 
             if solve_per == "array":

--- a/quartical/gains/general/convenience.py
+++ b/quartical/gains/general/convenience.py
@@ -81,6 +81,16 @@ def get_row(row_ind, row_map):
 
 
 @qcjit
+def get_extents(t_map, f_map):
+    """Given the time/freq mappings, determine run start and stop indices."""
+
+    row_starts, row_stops = get_row_extents(t_map)
+    chan_starts, chan_stops = get_chan_extents(f_map)
+
+    return extent_tuple(row_starts, row_stops, chan_starts, chan_stops)
+
+
+@qcjit
 def get_chan_extents(f_map_arr):
     """Given the frequency mappings, determines the start/stop indices."""
 

--- a/quartical/gains/general/convenience.py
+++ b/quartical/gains/general/convenience.py
@@ -1,7 +1,18 @@
 # -*- coding: utf-8 -*-
 from numba import jit, types, generated_jit
 import numpy as np
+from collections import namedtuple
 
+
+extent_tuple = namedtuple(
+    "extent_tuple",
+    (
+        "row_starts",
+        "row_stops",
+        "chan_starts",
+        "chan_stops"
+    )
+)
 
 # Handy alias for functions that need to be jitted in this way.
 qcjit = jit(nogil=True,
@@ -70,8 +81,11 @@ def get_row(row_ind, row_map):
 
 
 @qcjit
-def get_chan_extents(f_map_arr, active_term, n_fint, n_chan):
+def get_chan_extents(f_map_arr):
     """Given the frequency mappings, determines the start/stop indices."""
+
+    n_fint = f_map_arr.max() + 1
+    n_chan = f_map_arr.size
 
     chan_starts = np.empty(n_fint, dtype=np.int32)
     chan_starts[0] = 0
@@ -81,27 +95,27 @@ def get_chan_extents(f_map_arr, active_term, n_fint, n_chan):
 
     # NOTE: This might not be correct for decreasing channel freqs.
     if n_fint > 1:
-        chan_starts[1:] = 1 + np.where(
-            f_map_arr[1:, active_term] - f_map_arr[:-1, active_term])[0]
+        chan_starts[1:] = 1 + np.where(f_map_arr[1:] - f_map_arr[:-1])[0]
         chan_stops[:-1] = chan_starts[1:]
 
     return chan_starts, chan_stops
 
 
 @qcjit
-def get_row_extents(t_map_arr, active_term, n_tint):
+def get_row_extents(t_map_arr):
     """Given the time mappings, determines the row start/stop indices."""
+
+    n_tint = t_map_arr.max() + 1
 
     row_starts = np.empty(n_tint, dtype=np.int32)
     row_starts[0] = 0
 
     row_stops = np.empty(n_tint, dtype=np.int32)
-    row_stops[-1] = t_map_arr[:, active_term].size
+    row_stops[-1] = t_map_arr.size
 
     # NOTE: This assumes time ordered data (row runs).
     if n_tint > 1:
-        row_starts[1:] = 1 + np.where(
-            t_map_arr[1:, active_term] - t_map_arr[:-1, active_term])[0]
+        row_starts[1:] = 1 + np.where(t_map_arr[1:] - t_map_arr[:-1])[0]
         row_stops[:-1] = row_starts[1:]
 
     return row_starts, row_stops

--- a/quartical/gains/general/generics.py
+++ b/quartical/gains/general/generics.py
@@ -37,7 +37,7 @@ upsampled_itermediaries = namedtuple(
 resample_outputs = namedtuple(
     "resample_outputs",
     (
-        "required",
+        "active",
         "upsample_shape",
         "upsample_t_map",
         "downsample_t_map"
@@ -485,17 +485,17 @@ def resample_solints(native_map, native_shape, n_thread):
 
         if n_int < n_thread:  # TODO: Maybe put some integer factor here?
 
-            required = True
+            active = True
 
             remap_factor = np.ceil(n_thread/n_int)
 
-            target_n_int = int(n_int * remap_factor)
+            target_n_tint = int(n_tint * remap_factor)
 
             upsample_map = np.empty_like(native_map)
-            downsample_map = np.empty(target_n_int, dtype=np.int32)
+            downsample_map = np.empty(target_n_tint, dtype=np.int32)
             remap_id = 0
 
-            for i in range(n_int):
+            for i in range(n_tint):
 
                 sel = np.where(native_map == i)
 
@@ -515,17 +515,17 @@ def resample_solints(native_map, native_shape, n_thread):
                     consumed_rows -= upsample_n_row
                     remap_id += 1
 
-            upsample_shape = (target_n_int,) + native_shape[1:]
+            upsample_shape = (target_n_tint,) + native_shape[1:]
 
         else:
 
-            required = False
+            active = False
             upsample_map = native_map
             downsample_map = np.empty(0, dtype=np.int32)
             upsample_shape = native_shape
 
         return resample_outputs(
-            required, upsample_shape, upsample_map, downsample_map
+            active, upsample_shape, upsample_map, downsample_map
         )
 
     return impl

--- a/quartical/gains/general/generics.py
+++ b/quartical/gains/general/generics.py
@@ -544,11 +544,12 @@ def downsample_jhj_jhr(upsampled_imdry, downsample_t_map):
         prev_out_ti = -1
 
         for ti in range(n_tint):
+
+            out_ti = downsample_t_map[ti]
+
             for fi in range(n_fint):
                 for a in range(n_ant):
                     for d in range(n_dir):
-
-                        out_ti = downsample_t_map[ti]
 
                         if prev_out_ti != out_ti:
                             jhj[out_ti, fi, a, d] = jhj[ti, fi, a, d]
@@ -557,6 +558,6 @@ def downsample_jhj_jhr(upsampled_imdry, downsample_t_map):
                             jhj[out_ti, fi, a, d] += jhj[ti, fi, a, d]
                             jhr[out_ti, fi, a, d] += jhr[ti, fi, a, d]
 
-                        prev_out_ti = out_ti
+            prev_out_ti = out_ti
 
     return impl

--- a/quartical/gains/phase/kernel.py
+++ b/quartical/gains/phase/kernel.py
@@ -2,21 +2,22 @@
 import numpy as np
 from numba import prange, generated_jit
 from quartical.utils.numba import coerce_literal
-from quartical.gains.general.generics import (solver_intermediaries,
-                                              per_array_jhj_jhr)
+from quartical.gains.general.generics import (native_intermediaries,
+                                              upsampled_itermediaries,
+                                              per_array_jhj_jhr,
+                                              resample_solints,
+                                              downsample_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
                                               apply_gain_flags,
                                               update_param_flags)
 from quartical.gains.general.convenience import (get_row,
-                                                 get_chan_extents,
-                                                 get_row_extents)
+                                                 get_extents)
 import quartical.gains.general.factories as factories
 from quartical.gains.general.inversion import (invert_factory,
                                                inversion_buffer_factory)
 from collections import namedtuple
-
 
 # This can be done without a named tuple now. TODO: Add unpacking to
 # constructor.
@@ -65,44 +66,66 @@ def phase_solver(base_args, term_args, meta_args, corr_mode):
         max_iter = meta_args.iters
         solve_per = meta_args.solve_per
         dd_term = meta_args.dd_term
+        n_thread = meta_args.threads
 
         active_gain = gains[active_term]
         active_gain_flags = gain_flags[active_term]
         active_params = term_args.params[active_term]
 
-        # Set up some intemediaries used for flagging. TODO: Move?
+        # Set up some intemediaries used for flagging.
         km1_gain = active_gain.copy()
         km1_abs2_diffs = np.zeros_like(active_gain_flags, dtype=np.float64)
         abs2_diffs_trend = np.zeros_like(active_gain_flags, dtype=np.float64)
         flag_imdry = \
             flag_intermediaries(km1_gain, km1_abs2_diffs, abs2_diffs_trend)
 
-        # Set up some intemediaries used for solving. TODO: Move?
+        # Set up some intemediaries used for solving.
         real_dtype = active_gain.real.dtype
-        pshape = active_params.shape
-        jhj = np.empty(pshape + (pshape[-1],), dtype=real_dtype)
-        jhr = np.empty(pshape, dtype=real_dtype)
-        update = np.zeros_like(jhr)
-        solver_imdry = solver_intermediaries(jhj, jhr, update)
+        param_shape = active_params.shape
+
+        active_t_map_g = base_args.t_map_arr[0, :, active_term]
+        active_f_map_g = base_args.f_map_arr[0, :, active_term]
+
+        # Create more work to do in paralllel when needed, else no-op.
+        resampler = resample_solints(active_t_map_g, param_shape, n_thread)
+
+        # Determine the starts and stops of the rows and channels associated
+        # with each solution interval.
+        extents = get_extents(resampler.upsample_t_map, active_f_map_g)
+
+        upsample_shape = resampler.upsample_shape
+        upsampled_jhj = np.empty(upsample_shape + (upsample_shape[-1],),
+                                 dtype=real_dtype)
+        upsampled_jhr = np.empty(upsample_shape, dtype=real_dtype)
+        jhj = upsampled_jhj[:param_shape[0]]
+        jhr = upsampled_jhr[:param_shape[0]]
+        update = np.zeros(param_shape, dtype=real_dtype)
+
+        upsampled_imdry = upsampled_itermediaries(upsampled_jhj, upsampled_jhr)
+        native_imdry = native_intermediaries(jhj, jhr, update)
 
         for loop_idx in range(max_iter):
 
             compute_jhj_jhr(base_args,
                             term_args,
                             meta_args,
-                            solver_imdry,
+                            upsampled_imdry,
+                            extents,
                             corr_mode)
 
-            if solve_per == "array":
-                per_array_jhj_jhr(solver_imdry)
+            if resampler.active:
+                downsample_jhj_jhr(upsampled_imdry, resampler.downsample_t_map)
 
-            compute_update(solver_imdry,
+            if solve_per == "array":
+                per_array_jhj_jhr(native_imdry)
+
+            compute_update(native_imdry,
                            corr_mode)
 
             finalize_update(base_args,
                             term_args,
                             meta_args,
-                            solver_imdry,
+                            native_imdry,
                             loop_idx,
                             corr_mode)
 
@@ -138,7 +161,7 @@ def phase_solver(base_args, term_args, meta_args, corr_mode):
             apply_gain_flags(base_args,
                              meta_args)
 
-        return jhj, term_conv_info(loop_idx + 1, conv_perc)
+        return native_imdry.jhj, term_conv_info(loop_idx + 1, conv_perc)
 
     return impl
 
@@ -152,7 +175,8 @@ def compute_jhj_jhr(
     base_args,
     term_args,
     meta_args,
-    solver_imdry,
+    upsampled_imdry,
+    extents,
     corr_mode
 ):
 
@@ -178,7 +202,8 @@ def compute_jhj_jhr(
         base_args,
         term_args,
         meta_args,
-        solver_imdry,
+        upsampled_imdry,
+        extents,
         corr_mode
     ):
 
@@ -198,8 +223,8 @@ def compute_jhj_jhr(
         f_map_arr = base_args.f_map_arr[0]  # We only need the gain mappings.
         d_map_arr = base_args.d_map_arr
 
-        jhj = solver_imdry.jhj
-        jhr = solver_imdry.jhr
+        jhj = upsampled_imdry.jhj
+        jhr = upsampled_imdry.jhr
 
         _, n_chan, n_dir, n_corr = model.shape
 
@@ -214,16 +239,10 @@ def compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        # Determine the starts and stops of the rows and channels associated
-        # with each solution interval. This could even be moved out for speed.
-        row_starts, row_stops = get_row_extents(t_map_arr,
-                                                active_term,
-                                                n_tint)
-
-        chan_starts, chan_stops = get_chan_extents(f_map_arr,
-                                                   active_term,
-                                                   n_fint,
-                                                   n_chan)
+        row_starts = extents.row_starts
+        row_stops = extents.row_stops
+        chan_starts = extents.chan_starts
+        chan_stops = extents.chan_stops
 
         # Determine loop variables based on where we are in the chain.
         # gt means greater than (n>j) and lt means less than (n<j).
@@ -384,20 +403,20 @@ def compute_jhj_jhr(
                parallel=True,
                cache=True,
                nogil=True)
-def compute_update(solver_imdry, corr_mode):
+def compute_update(native_imdry, corr_mode):
 
     # We want to dispatch based on this field so we need its type.
-    jhj = solver_imdry[solver_imdry.fields.index('jhj')]
+    jhj = native_imdry[native_imdry.fields.index('jhj')]
 
     generalised = jhj.ndim == 6
     inversion_buffer = inversion_buffer_factory(generalised=generalised)
     invert = invert_factory(corr_mode, generalised=generalised)
 
-    def impl(solver_imdry, corr_mode):
+    def impl(native_imdry, corr_mode):
 
-        jhj = solver_imdry.jhj
-        jhr = solver_imdry.jhr
-        update = solver_imdry.update
+        jhj = native_imdry.jhj
+        jhr = native_imdry.jhr
+        update = native_imdry.update
 
         n_tint, n_fint, n_ant, n_dir, n_param = jhr.shape
 
@@ -425,13 +444,13 @@ def compute_update(solver_imdry, corr_mode):
 
 @generated_jit(nopython=True, fastmath=True, parallel=False, cache=True,
                nogil=True)
-def finalize_update(base_args, term_args, meta_args, solver_imdry, loop_idx,
+def finalize_update(base_args, term_args, meta_args, native_imdry, loop_idx,
                     corr_mode):
 
     set_identity = factories.set_identity_factory(corr_mode)
     param_to_gain = param_to_gain_factory(corr_mode)
 
-    def impl(base_args, term_args, meta_args, solver_imdry, loop_idx,
+    def impl(base_args, term_args, meta_args, native_imdry, loop_idx,
              corr_mode):
 
         active_term = meta_args.active_term
@@ -441,7 +460,7 @@ def finalize_update(base_args, term_args, meta_args, solver_imdry, loop_idx,
 
         params = term_args.params[active_term]
 
-        update = solver_imdry.update
+        update = native_imdry.update
 
         n_tint, n_fint, n_ant, n_dir, n_corr = gain.shape
 

--- a/quartical/gains/rotation_measure/kernel.py
+++ b/quartical/gains/rotation_measure/kernel.py
@@ -2,16 +2,18 @@
 import numpy as np
 from numba import prange, generated_jit
 from quartical.utils.numba import coerce_literal
-from quartical.gains.general.generics import (solver_intermediaries,
-                                              per_array_jhj_jhr)
+from quartical.gains.general.generics import (native_intermediaries,
+                                              upsampled_itermediaries,
+                                              per_array_jhj_jhr,
+                                              resample_solints,
+                                              downsample_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
                                               apply_gain_flags,
                                               update_param_flags)
 from quartical.gains.general.convenience import (get_row,
-                                                 get_chan_extents,
-                                                 get_row_extents)
+                                                 get_extents)
 import quartical.gains.general.factories as factories
 from quartical.gains.general.inversion import (invert_factory,
                                                inversion_buffer_factory)
@@ -64,6 +66,7 @@ def rm_solver(base_args, term_args, meta_args, corr_mode):
         max_iter = meta_args.iters
         solve_per = meta_args.solve_per
         dd_term = meta_args.dd_term
+        n_thread = meta_args.threads
 
         active_gain = gains[active_term]
         active_gain_flags = gain_flags[active_term]
@@ -76,13 +79,30 @@ def rm_solver(base_args, term_args, meta_args, corr_mode):
         flag_imdry = \
             flag_intermediaries(km1_gain, km1_abs2_diffs, abs2_diffs_trend)
 
-        # Set up some intemediaries used for solving. TODO: Move?
+        # Set up some intemediaries used for solving.
         real_dtype = active_gain.real.dtype
-        pshape = active_params.shape
-        jhj = np.empty(pshape + (pshape[-1],), dtype=real_dtype)
-        jhr = np.empty(pshape, dtype=real_dtype)
-        update = np.zeros_like(jhr)
-        solver_imdry = solver_intermediaries(jhj, jhr, update)
+        param_shape = active_params.shape
+
+        active_t_map_g = base_args.t_map_arr[0, :, active_term]
+        active_f_map_p = base_args.f_map_arr[1, :, active_term]
+
+        # Create more work to do in paralllel when needed, else no-op.
+        resampler = resample_solints(active_t_map_g, param_shape, n_thread)
+
+        # Determine the starts and stops of the rows and channels associated
+        # with each solution interval.
+        extents = get_extents(resampler.upsample_t_map, active_f_map_p)
+
+        upsample_shape = resampler.upsample_shape
+        upsampled_jhj = np.empty(upsample_shape + (upsample_shape[-1],),
+                                 dtype=real_dtype)
+        upsampled_jhr = np.empty(upsample_shape, dtype=real_dtype)
+        jhj = upsampled_jhj[:param_shape[0]]
+        jhr = upsampled_jhr[:param_shape[0]]
+        update = np.zeros(param_shape, dtype=real_dtype)
+
+        upsampled_imdry = upsampled_itermediaries(upsampled_jhj, upsampled_jhr)
+        native_imdry = native_intermediaries(jhj, jhr, update)
 
         chan_freqs = term_args.chan_freqs
         lambda_sq = (299792458/chan_freqs)**2
@@ -92,20 +112,24 @@ def rm_solver(base_args, term_args, meta_args, corr_mode):
             compute_jhj_jhr(base_args,
                             term_args,
                             meta_args,
-                            solver_imdry,
+                            upsampled_imdry,
+                            extents,
                             lambda_sq,
                             corr_mode)
 
-            if solve_per == "array":
-                per_array_jhj_jhr(solver_imdry)
+            if resampler.active:
+                downsample_jhj_jhr(upsampled_imdry, resampler.downsample_t_map)
 
-            compute_update(solver_imdry,
+            if solve_per == "array":
+                per_array_jhj_jhr(native_imdry)
+
+            compute_update(native_imdry,
                            corr_mode)
 
             finalize_update(base_args,
                             term_args,
                             meta_args,
-                            solver_imdry,
+                            native_imdry,
                             lambda_sq,
                             loop_idx,
                             corr_mode)
@@ -141,7 +165,7 @@ def rm_solver(base_args, term_args, meta_args, corr_mode):
             apply_gain_flags(base_args,
                              meta_args)
 
-        return jhj, term_conv_info(loop_idx + 1, conv_perc)
+        return native_imdry.jhj, term_conv_info(loop_idx + 1, conv_perc)
 
     return impl
 
@@ -155,7 +179,8 @@ def compute_jhj_jhr(
     base_args,
     term_args,
     meta_args,
-    solver_imdry,
+    upsampled_imdry,
+    extents,
     lambda_sq,
     corr_mode
 ):
@@ -181,7 +206,8 @@ def compute_jhj_jhr(
         base_args,
         term_args,
         meta_args,
-        solver_imdry,
+        upsampled_imdry,
+        extents,
         lambda_sq,
         corr_mode
     ):
@@ -204,8 +230,8 @@ def compute_jhj_jhr(
         f_map_arr_p = base_args.f_map_arr[1]
         d_map_arr = base_args.d_map_arr
 
-        jhj = solver_imdry.jhj
-        jhr = solver_imdry.jhr
+        jhj = upsampled_imdry.jhj
+        jhr = upsampled_imdry.jhr
 
         _, n_chan, n_dir, n_corr = model.shape
 
@@ -220,16 +246,10 @@ def compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        # Determine the starts and stops of the rows and channels associated
-        # with each solution interval. This could even be moved out for speed.
-        row_starts, row_stops = get_row_extents(t_map_arr,
-                                                active_term,
-                                                n_tint)
-
-        chan_starts, chan_stops = get_chan_extents(f_map_arr_p,
-                                                   active_term,
-                                                   n_fint,
-                                                   n_chan)
+        row_starts = extents.row_starts
+        row_stops = extents.row_stops
+        chan_starts = extents.chan_starts
+        chan_stops = extents.chan_stops
 
         # Determine loop variables based on where we are in the chain.
         # gt means greater than (n>j) and lt means less than (n<j).
@@ -400,20 +420,20 @@ def compute_jhj_jhr(
                parallel=True,
                cache=True,
                nogil=True)
-def compute_update(solver_imdry, corr_mode):
+def compute_update(native_imdry, corr_mode):
 
     # We want to dispatch based on this field so we need its type.
-    jhj = solver_imdry[solver_imdry.fields.index('jhj')]
+    jhj = native_imdry[native_imdry.fields.index('jhj')]
 
     generalised = jhj.ndim == 6
     inversion_buffer = inversion_buffer_factory(generalised=generalised)
     invert = invert_factory(corr_mode, generalised=generalised)
 
-    def impl(solver_imdry, corr_mode):
+    def impl(native_imdry, corr_mode):
 
-        jhj = solver_imdry.jhj
-        jhr = solver_imdry.jhr
-        update = solver_imdry.update
+        jhj = native_imdry.jhj
+        jhr = native_imdry.jhr
+        update = native_imdry.update
 
         n_tint, n_fint, n_ant, n_dir, n_param = jhr.shape
 
@@ -441,13 +461,13 @@ def compute_update(solver_imdry, corr_mode):
 
 @generated_jit(nopython=True, fastmath=True, parallel=False, cache=True,
                nogil=True)
-def finalize_update(base_args, term_args, meta_args, solver_imdry, lambda_sq,
+def finalize_update(base_args, term_args, meta_args, native_imdry, lambda_sq,
                     loop_idx, corr_mode):
 
     set_identity = factories.set_identity_factory(corr_mode)
 
     if corr_mode.literal_value == 4:
-        def impl(base_args, term_args, meta_args, solver_imdry, lambda_sq,
+        def impl(base_args, term_args, meta_args, native_imdry, lambda_sq,
                  loop_idx, corr_mode):
 
             active_term = meta_args.active_term
@@ -459,7 +479,7 @@ def finalize_update(base_args, term_args, meta_args, solver_imdry, lambda_sq,
 
             params = term_args.params[active_term]
 
-            update = solver_imdry.update
+            update = native_imdry.update
 
             update /= 2
             params += update


### PR DESCRIPTION
This PR addresses a long-standing issue - what do we do when we have very large solution intervals? QuartiCal already has the ability to process solution intervals in parallel. However, the limiting case (which is not entirely unusual) of `(inf, inf)` solution intervals leaves us with no (easy) axis over which to do things in parallel.

I have attempted many different approaches (see branch name), all of which had a sharp edge such as performance degradation or increased memory footprint. The approach in this PR is the culmination of all those previous attempts and should allow for an arbitrary degree of internal parallelism with low to virtually non-existent memory and compute overheads.

For the sake of posterity, I will quickly detail the idea behind the approach (which is actually fairly simple). The main driver behind these changes was the realization that accumulation over solution interval is completely arbitrary i.e. we are free to sum the elements contributing to a solution interval in any order and (more importantly) need not accumulate them into a single element immediately. QuartiCal now leverages this behavior to create an upsampled (slight misnomer) grid of solution intervals in time if and only if we are in a regime where we need to partition the problem into something we can process in parallel. This means that when we have a reasonable number solution intervals, the new code effectively does nothing i.e. has virtually no impact on memory or performance. However, when we have very large solution intervals they will be automatically partitioned into sub-intervals which can be processed in parallel. This has slight memory and compute overheads which scale with the inverse of the number of solution intervals i.e. the memory and compute overheads are are at their worst when we have `(inf, inf)` solution intervals. This is, however, largely irrelevant as `(inf, inf)` solution intervals already imply a memory reduction of order `n_time*n_chan*n_ant`. The potential `n_thread` increase is negligible next to this reduction. The additional compute is associated with accumulating the sub-intervals onto the so-called native intervals and is very cheap as it happens at the resolution of the solution intervals i.e. the accumulation is only over a small array.

There are still further improvements which can be made should the need arise, but I am relatively confident that this should suffice for most reasonable use cases.