### PR TITLE
Add s3 to dask-ms dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = [
     "columnar",
     "ruamel.yaml",
     "numpy",
-    "dask-ms[xarray, zarr]>=0.2.9",
+    "dask-ms[xarray, zarr, s3]>=0.2.9",
     "codex-africanus[dask, scipy, astropy, python-casacore]",
     "dask[array]",
     "astro-tigger-lsm",


### PR DESCRIPTION
We want to support s3 by default, so this should be installed by default.