### PR TITLE
Compose net gains from arbitrary terms.

### DIFF
--- a/quartical/calibration/calibrate.py
+++ b/quartical/calibration/calibrate.py
@@ -126,17 +126,19 @@ def add_calibration_graph(data_xds_list, solver_opts, chain_opts, output_opts):
 
     # Construct an effective gain per data_xds. This is always at the full
     # time and frequency resolution of the data.
-    net_xds_list = make_net_xds_list(
+    net_xds_lod = make_net_xds_list(
         data_xds_list,
-        coords_per_xds
+        coords_per_xds,
+        output_opts
     )
 
-    net_xds_list = populate_net_xds_list(
-        net_xds_list,
+    net_xds_lod = populate_net_xds_list(
+        net_xds_lod,
         gain_xds_lod,
         t_bin_list,
         f_map_list,
-        d_map_list
+        d_map_list,
+        output_opts
     )
 
     # Update the data xarray.Datasets with visibility outputs.
@@ -150,7 +152,7 @@ def add_calibration_graph(data_xds_list, solver_opts, chain_opts, output_opts):
     )
 
     # Return the resulting graphs for the gains and updated xds.
-    return gain_xds_lod, net_xds_list, data_xds_list
+    return gain_xds_lod, net_xds_lod, data_xds_list
 
 
 def make_visibility_output(data_xds_list, solved_gain_xds_lod, t_map_list,

--- a/quartical/calibration/calibrate.py
+++ b/quartical/calibration/calibrate.py
@@ -124,22 +124,25 @@ def add_calibration_graph(data_xds_list, solver_opts, chain_opts, output_opts):
         chain_opts
     )
 
-    # Construct an effective gain per data_xds. This is always at the full
-    # time and frequency resolution of the data.
-    net_xds_lod = make_net_xds_list(
-        data_xds_list,
-        coords_per_xds,
-        output_opts
-    )
+    if output_opts.net_gains:
+        # Construct an effective gain per data_xds. This is always at the full
+        # time and frequency resolution of the data.
+        net_xds_lod = make_net_xds_list(
+            data_xds_list,
+            coords_per_xds,
+            output_opts
+        )
 
-    net_xds_lod = populate_net_xds_list(
-        net_xds_lod,
-        gain_xds_lod,
-        t_bin_list,
-        f_map_list,
-        d_map_list,
-        output_opts
-    )
+        net_xds_lod = populate_net_xds_list(
+            net_xds_lod,
+            gain_xds_lod,
+            t_bin_list,
+            f_map_list,
+            d_map_list,
+            output_opts
+        )
+    else:
+        net_xds_lod = []
 
     # Update the data xarray.Datasets with visibility outputs.
     data_xds_list = make_visibility_output(

--- a/quartical/config/external.py
+++ b/quartical/config/external.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field, make_dataclass, fields
 from omegaconf import OmegaConf as oc
-from typing import List, Optional
+from typing import List, Optional, Any
 from quartical.config.converters import as_time, as_freq
 
 
@@ -101,7 +101,7 @@ class Outputs(Input):
     flags: bool = True
     apply_p_jones_inv: bool = True
     subtract_directions: Optional[List[int]] = None
-    net_gain: bool = False
+    net_gains: Optional[List[Any]] = None
 
     def __post_init__(self):
         self.validate_choice_fields()
@@ -110,6 +110,18 @@ class Outputs(Input):
         if self.products:
             assert len(self.products) == len(self.columns), \
                    "Number of products not equal to number of columns."
+        if self.net_gains:
+            nested = any(isinstance(i, list) for i in self.net_gains)
+            if nested:
+                assert all(isinstance(i, list) for i in self.net_gains), \
+                    ("Contents of outputs.net_gains not understood. "
+                     "Must be strictly a list or list of lists.")
+            else:
+                assert all(isinstance(i, str) for i in self.net_gains), \
+                    ("Contents of outputs.net_gains not understood. "
+                     "Must be strictly a list or list of lists.")
+                # In the non-nested case, introduce outer list (consistent).
+                self.net_gains = [self.net_gains]
 
 
 @dataclass

--- a/quartical/config/helpstrings.yaml
+++ b/quartical/config/helpstrings.yaml
@@ -115,11 +115,13 @@ output:
     applied to the output visibilitites. This has the effect of derotating
     the output visibilities into the sky frame. Care must taken when using
     this option and input_model.apply_p_jones.
-  net_gain:
-    Output the effective/net gain per antenna per time per channel. This
-    is formed by multiplying all the gain terms together. This can be used
-    to reduce the computational load of solution transfer by transferring the
-    effective gain rather than each individual term.
+  net_gains:
+    Merge subsets of gains into an effective/net gain per antenna per time per
+    channel. This is formed by multiplying all the specified gains together.
+    This can be used to reduce the computational load of solution transfer by
+    transferring merged gains rather than each individual term. Accepts a list
+    or a list of lists e.g. ["K", "G", "X", "B"] or [["K", "G"], ["X", "B"]].
+    Results will be written to outputs.gain_directory as e.g. KGXB-net.
   subtract_directions:
     Which model directions to subtract when generating residuals. Must be
     specified as a list of integers e.g. [0, 5, 7]. The default will subtract

--- a/quartical/executor.py
+++ b/quartical/executor.py
@@ -117,7 +117,7 @@ def _execute(exitstack):
 
     # Adds the dask graph describing the calibration of the data. TODO:
     # This call has excess functionality now. Split out mapping and outputs.
-    gain_xds_lod, net_xds_list, data_xds_list = add_calibration_graph(
+    gain_xds_lod, net_xds_lod, data_xds_list = add_calibration_graph(
         data_xds_list,
         solver_opts,
         chain_opts,
@@ -143,7 +143,7 @@ def _execute(exitstack):
                                output_opts)
 
     gain_writes = write_gain_datasets(gain_xds_lod,
-                                      net_xds_list,
+                                      net_xds_lod,
                                       output_opts)
 
     logger.success("{:.2f} seconds taken to build graph.", time.time() - t0)

--- a/quartical/gains/datasets.py
+++ b/quartical/gains/datasets.py
@@ -188,63 +188,75 @@ def compute_dataset_coords(data_xds_list,
     return da.compute(coords_per_xds)[0]
 
 
-def make_net_xds_list(data_xds_list, coords_per_xds):
+def make_net_xds_list(data_xds_list, coords_per_xds, output_opts):
     """Construct a list of dicts of xarray.Datasets to house the net gains.
 
     Args:
         data_xds_list: A List of xarray.Dataset objects containing MS data.
         coords_per_xds: A List of Dicts containing dataset coords.
+        output_opts: An output config object.
 
     Returns:
-        net_gain_xds_list: A List of xarray.Dataset objects to house
+        net_gain_xds_dol: A Dict of Lists of xarray.Dataset objects to house
             the net gains.
     """
 
-    net_gain_xds_list = []
+    net_names = [f"{''.join(lt)}-net" for lt in output_opts.net_gains]
+
+    net_gain_xds_lod = []
 
     for data_xds, xds_coords in zip(data_xds_list, coords_per_xds):
 
         net_t_chunks = np.tile(data_xds.UTIME_CHUNKS, 2).reshape(2, -1)
         net_f_chunks = np.tile(data_xds.chunks["chan"], 2).reshape(2, -1)
 
-        # Create a default config object, consistent with the net gain.
-        # NOTE: If we have a direction-dependent model, assume the net gain
-        # is also direction dependent.
-        config = Gain(direction_dependent=bool(data_xds.dims["dir"]))
+        net_dict = {}
 
-        net_obj = TERM_TYPES["complex"]("NET",
-                                        config,
-                                        data_xds,
-                                        xds_coords,
-                                        net_t_chunks,
-                                        net_f_chunks)
+        for net_name in net_names:
 
-        net_gain_xds_list.append(net_obj.make_xds())
+            # Create a default config object, consistent with the net gain.
+            # NOTE: If we have a direction-dependent model, assume the net gain
+            # is also direction dependent.
+            config = Gain(direction_dependent=bool(data_xds.dims["dir"]))
 
-    return net_gain_xds_list
+            net_obj = TERM_TYPES["complex"](net_name,
+                                            config,
+                                            data_xds,
+                                            xds_coords,
+                                            net_t_chunks,
+                                            net_f_chunks)
+
+            net_dict[net_name] = net_obj.make_xds()
+
+        net_gain_xds_lod.append(net_dict)
+
+    return net_gain_xds_lod
 
 
-def combine_gains_wrapper(t_bin_arr, f_map_arr, d_map_arr, net_shape,
+def combine_gains_wrapper(t_bin_arr, f_map_arr, d_map_arr, term_ids, net_shape,
                           corr_mode, *gains):
     """Wrapper to stop dask from getting confused. See issue #99."""
 
-    return combine_gains(t_bin_arr, f_map_arr, d_map_arr, net_shape,
+    return combine_gains(t_bin_arr, f_map_arr, d_map_arr, term_ids, net_shape,
                          corr_mode, *gains)
 
 
-def combine_flags_wrapper(t_bin_arr, f_map_arr, d_map_arr, net_shape,
+def combine_flags_wrapper(t_bin_arr, f_map_arr, d_map_arr, term_ids, net_shape,
                           corr_mode, *flags):
     """Wrapper to stop dask from getting confused. See issue #99."""
 
-    return combine_flags(t_bin_arr, f_map_arr, d_map_arr, net_shape,
+    return combine_flags(t_bin_arr, f_map_arr, d_map_arr, term_ids, net_shape,
                          corr_mode, *flags)
 
 
-def populate_net_xds_list(net_gain_xds_list,
-                          solved_gain_xds_lod,
-                          t_bin_list,
-                          f_map_list,
-                          d_map_list):
+def populate_net_xds_list(
+    net_gain_xds_lod,
+    solved_gain_xds_lod,
+    t_bin_list,
+    f_map_list,
+    d_map_list,
+    output_opts
+):
     """Poplulate the list net gain datasets with net gain values.
 
     Args:
@@ -258,89 +270,113 @@ def populate_net_xds_list(net_gain_xds_list,
             to solution interval.
         d_map_list: A List of numpy.ndarrays containing mappings between
             direction dependent terms and direction independent terms.
+        output_opts: An output configuration object,
 
     Returns:
         net_gain_xds_list: A List of xarray.Dataset objects to house the
             net gains.
     """
 
-    populated_net_gain_xds_list = []
+    net_terms = output_opts.net_gains
 
-    for ind, (terms, net_xds) in enumerate(zip(solved_gain_xds_lod,
-                                               net_gain_xds_list)):
+    # User has not requested net gains. TODO: Move out?
+    if net_terms is None:
+        return net_gain_xds_lod
 
-        net_shape = tuple(net_xds.dims[d]
-                          for d in ["gain_t", "gain_f", "ant", "dir", "corr"])
+    net_names = [f"{''.join(lt)}-net" for lt in net_terms]
 
-        gain_schema = ("time", "chan", "ant", "dir", "corr")
+    net_map = dict(zip(net_names, net_terms))
 
-        gains = [x for xds in terms.values()
-                 for x in (xds.gains.data, gain_schema)]
-        corr_mode = net_shape[-1]
-        dtype = np.find_common_type(
-            [xds.gains.dtype for xds in terms.values()], []
+    gain_dims = ("gain_t", "gain_f", "ant", "dir", "corr")
+    gain_schema = ("time", "chan", "ant", "dir", "corr")
+    flag_schema = ("time", "chan", "ant", "dir")
+    populated_net_gain_xds_lod = []
+
+    for ind, (solved_gains, net_gains) in enumerate(zip(solved_gain_xds_lod,
+                                                        net_gain_xds_lod)):
+
+        gains = [itm for xds in solved_gains.values()
+                 for itm in (xds.gains.data, gain_schema)]
+        gain_dtype = np.find_common_type(
+            [xds.gains.data.dtype for xds in solved_gains.values()], []
+        )
+        identity_elements = {
+            1: np.ones(1, dtype=gain_dtype),
+            2: np.ones(2, dtype=gain_dtype),
+            4: np.array((1, 0, 0, 1), dtype=gain_dtype)
+        }
+
+        flags = [itm for xds in solved_gains.values()
+                 for itm in (xds.gain_flags.data, flag_schema)]
+        flag_dtype = np.find_common_type(
+            [xds.gain_flags.dtype for xds in solved_gains.values()], []
         )
 
-        identity_elements = {1: np.ones(1, dtype=dtype),
-                             2: np.ones(2, dtype=dtype),
-                             4: np.array((1, 0, 0, 1), dtype=dtype)}
+        net_xds_dict = {}
 
-        net_gain = da.blockwise(
-            combine_gains_wrapper, ("time", "chan", "ant", "dir", "corr"),
-            t_bin_list[ind], ("param", "time", "term"),
-            f_map_list[ind], ("param", "chan", "term"),
-            d_map_list[ind], None,
-            net_shape, None,
-            corr_mode, None,
-            *gains,
-            dtype=dtype,
-            align_arrays=False,
-            concatenate=True,
-            adjust_chunks={"time": net_xds.GAIN_SPEC.tchunk,
-                           "chan": net_xds.GAIN_SPEC.fchunk,
-                           "dir": net_xds.GAIN_SPEC.dchunk}
-        )
+        for net_name, req_terms in net_map.items():
 
-        flag_schema = ("time", "chan", "ant", "dir")
+            net_xds = net_gains[net_name]
 
-        flags = [x for xds in terms.values()
-                 for x in (xds.gain_flags.data, flag_schema)]
-        dtype = np.find_common_type(
-            [xds.gain_flags.dtype for xds in terms.values()], []
-        )
+            net_shape = tuple(net_xds.dims[d] for d in gain_dims)
 
-        net_flags = da.blockwise(
-            combine_flags_wrapper, ("time", "chan", "ant", "dir"),
-            t_bin_list[ind], ("param", "time", "term"),
-            f_map_list[ind], ("param", "chan", "term"),
-            d_map_list[ind], None,
-            net_shape[:-1], None,
-            *flags,
-            dtype=dtype,
-            align_arrays=False,
-            concatenate=True,
-            adjust_chunks={"time": net_xds.GAIN_SPEC.tchunk,
-                           "chan": net_xds.GAIN_SPEC.fchunk,
-                           "dir": net_xds.GAIN_SPEC.dchunk}
-        )
+            corr_mode = net_shape[-1]
 
-        net_gain = da.where(net_flags[..., None],
-                            identity_elements[corr_mode],
-                            net_gain)
+            req_term_ids = \
+                [list(solved_gains.keys()).index(tn) for tn in req_terms]
 
-        net_xds = net_xds.assign(
-            {
-                "gains": (net_xds.GAIN_AXES, net_gain),
-                "gain_flags": (net_xds.GAIN_AXES[:-1], net_flags)
-            }
-        )
+            net_gain = da.blockwise(
+                combine_gains_wrapper, ("time", "chan", "ant", "dir", "corr"),
+                t_bin_list[ind], ("param", "time", "term"),
+                f_map_list[ind], ("param", "chan", "term"),
+                d_map_list[ind], None,
+                req_term_ids, None,
+                net_shape, None,
+                corr_mode, None,
+                *gains,
+                dtype=gain_dtype,
+                align_arrays=False,
+                concatenate=True,
+                adjust_chunks={"time": net_xds.GAIN_SPEC.tchunk,
+                               "chan": net_xds.GAIN_SPEC.fchunk,
+                               "dir": net_xds.GAIN_SPEC.dchunk}
+            )
 
-        populated_net_gain_xds_list.append(net_xds)
+            net_flags = da.blockwise(
+                combine_flags_wrapper, ("time", "chan", "ant", "dir"),
+                t_bin_list[ind], ("param", "time", "term"),
+                f_map_list[ind], ("param", "chan", "term"),
+                d_map_list[ind], None,
+                req_term_ids, None,
+                net_shape[:-1], None,
+                *flags,
+                dtype=flag_dtype,
+                align_arrays=False,
+                concatenate=True,
+                adjust_chunks={"time": net_xds.GAIN_SPEC.tchunk,
+                               "chan": net_xds.GAIN_SPEC.fchunk,
+                               "dir": net_xds.GAIN_SPEC.dchunk}
+            )
 
-    return populated_net_gain_xds_list
+            net_gain = da.where(net_flags[..., None],
+                                identity_elements[corr_mode],
+                                net_gain)
+
+            net_xds = net_xds.assign(
+                {
+                    "gains": (net_xds.GAIN_AXES, net_gain),
+                    "gain_flags": (net_xds.GAIN_AXES[:-1], net_flags)
+                }
+            )
+
+            net_xds_dict[net_name] = net_xds
+
+        populated_net_gain_xds_lod.append(net_xds_dict)
+
+    return populated_net_gain_xds_lod
 
 
-def write_gain_datasets(gain_xds_lod, net_xds_list, output_opts):
+def write_gain_datasets(gain_xds_lod, net_xds_lod, output_opts):
     """Write the contents of gain_xds_lol to zarr in accordance with opts."""
 
     gain_path = output_opts.gain_directory
@@ -349,11 +385,12 @@ def write_gain_datasets(gain_xds_lod, net_xds_list, output_opts):
 
     writable_xds_dol = {tn: [d[tn] for d in gain_xds_lod] for tn in term_names}
 
-    # If we are writing out the net/effective gains.
-    if output_opts.net_gain:
-        net_name = net_xds_list[0].NAME
-        term_names.append(net_name)
-        writable_xds_dol[net_name] = net_xds_list
+    # If net gains have been requested, add them to the writes.
+    if output_opts.net_gains:
+        net_names = [xds.NAME for xds in net_xds_lod[0].values()]
+        net_xds_dol = {tn: [d[tn] for d in net_xds_lod] for tn in net_names}
+        term_names.extend(net_names)
+        writable_xds_dol.update(net_xds_dol)
 
     gain_writes_lol = []
 

--- a/quartical/gains/datasets.py
+++ b/quartical/gains/datasets.py
@@ -279,10 +279,6 @@ def populate_net_xds_list(
 
     net_terms = output_opts.net_gains
 
-    # User has not requested net gains. TODO: Move out?
-    if net_terms is None:
-        return net_gain_xds_lod
-
     net_names = [f"{''.join(lt)}-net" for lt in net_terms]
 
     net_map = dict(zip(net_names, net_terms))
@@ -358,9 +354,10 @@ def populate_net_xds_list(
                                "dir": net_xds.GAIN_SPEC.dchunk}
             )
 
-            net_gain = da.where(net_flags[..., None],
-                                identity_elements[corr_mode],
-                                net_gain)
+            net_gain = da.blockwise(np.where, "tfadc",
+                                    net_flags[..., None], "tfadc",
+                                    identity_elements[corr_mode], None,
+                                    net_gain, "tfadc")
 
             net_xds = net_xds.assign(
                 {

--- a/quartical/gains/general/generics.py
+++ b/quartical/gains/general/generics.py
@@ -378,14 +378,15 @@ def compute_convergence(gain, last_gain, criteria):
 
 
 @qcgjit
-def combine_gains(t_bin_arr, f_map_arr, d_map_arr, net_shape, corr_mode,
-                  *gains):
+def combine_gains(t_bin_arr, f_map_arr, d_map_arr, term_ids, net_shape,
+                  corr_mode, *gains):
 
     coerce_literal(combine_gains, ["corr_mode"])
 
     v1_imul_v2 = factories.v1_imul_v2_factory(corr_mode)
 
-    def impl(t_bin_arr, f_map_arr, d_map_arr, net_shape, corr_mode, *gains):
+    def impl(t_bin_arr, f_map_arr, d_map_arr, term_ids, net_shape, corr_mode,
+             *gains):
         t_bin_arr = t_bin_arr[0]
         f_map_arr = f_map_arr[0]
 
@@ -399,13 +400,11 @@ def combine_gains(t_bin_arr, f_map_arr, d_map_arr, net_shape, corr_mode,
         net_gains[..., 0] = 1
         net_gains[..., -1] = 1
 
-        n_term = len(gains)
-
         for t in range(n_time):
             for f in range(n_freq):
                 for a in range(n_ant):
                     for d in range(n_dir):
-                        for gi in range(n_term):
+                        for gi in term_ids:
                             tm = t_bin_arr[t, gi]
                             fm = f_map_arr[f, gi]
                             dm = d_map_arr[gi, d]
@@ -419,9 +418,10 @@ def combine_gains(t_bin_arr, f_map_arr, d_map_arr, net_shape, corr_mode,
 
 
 @qcgjit
-def combine_flags(t_bin_arr, f_map_arr, d_map_arr, net_shape, *flags):
+def combine_flags(t_bin_arr, f_map_arr, d_map_arr, term_ids, net_shape,
+                  *flags):
 
-    def impl(t_bin_arr, f_map_arr, d_map_arr, net_shape, *flags):
+    def impl(t_bin_arr, f_map_arr, d_map_arr, term_ids, net_shape, *flags):
         t_bin_arr = t_bin_arr[0]
         f_map_arr = f_map_arr[0]
 
@@ -432,13 +432,11 @@ def combine_flags(t_bin_arr, f_map_arr, d_map_arr, net_shape, *flags):
 
         net_flags = np.zeros((n_time, n_freq, n_ant, n_dir), dtype=np.int8)
 
-        n_term = len(flags)
-
         for t in range(n_time):
             for f in range(n_freq):
                 for a in range(n_ant):
                     for d in range(n_dir):
-                        for gi in range(n_term):
+                        for gi in term_ids:
                             tm = t_bin_arr[t, gi]
                             fm = f_map_arr[f, gi]
                             dm = d_map_arr[gi, d]

--- a/testing/data/test_config.yaml
+++ b/testing/data/test_config.yaml
@@ -36,7 +36,7 @@ output:
   - residual
   columns:
   - TEST_RESIDUALS
-  net_gain: False
+  net_gains:
 mad_flags:
   enable: false
   threshold_bl: 10


### PR DESCRIPTION
As per @landmanbester's request, this replaces `output.net_gain` with `output.net_gains`. This new option accepts a list of strings or a list of lists of strings. If the first case, all listed terms will be combined into a single effective gain at full time and frequency resolution. In the second case, each sub-list will be combined into a separate effective gain.

This may be clearer with an example. Let us assume we specified `solver.terms=[G,K,B,X,D]`. We could now use `output.net_gains` to do any of the following:

- `output.net_gains=[G,K,B,X,D]`: produce a single net/effective gain which includes all the terms. This is consistent with the old behaviour. Output will be named `GKBXD-merged`.
- `output.net_gains=[G,K,B]`: Combine a subset of terms into an effective gain. Output will be named `GKB-merged`.
- `output.net_gains=[[G,K,B], [X,D]]`: Combine two subsets of terms into two effective gains. Outputs will be named `GKB-merged` and `XD-merged` respectively.
- `output.net_gains=[[G,K], [K,B]]`: Combine two subsets of terms (which overlap) into two effective gains. Outputs will be named `GK-merged` and `KB-merged` respectively. This may be useful for solution transfer.

One thing to note is that at present order matters i.e. `output.net_gains=[G,B]` will not produce the same output as `output.net_gains=[B,G]` if they are non-commuting terms. 