### PR TITLE
Improve MAD code

### DIFF
--- a/quartical/config/external.py
+++ b/quartical/config/external.py
@@ -136,8 +136,8 @@ class Outputs(Input):
 class MadFlags(Input):
     enable: bool = False
     threshold_bl: float = 5
-    threshold_global: float = 5
-    max_deviation: float = 5
+    threshold_global: float = 10
+    max_deviation: float = 10
 
     def __post_init__(self):
         self.validate_choice_fields()

--- a/quartical/config/external.py
+++ b/quartical/config/external.py
@@ -135,6 +135,7 @@ class Outputs(Input):
 @dataclass
 class MadFlags(Input):
     enable: bool = False
+    whiten: bool = True
     threshold_bl: float = 5
     threshold_global: float = 10
     max_deviation: float = 10

--- a/quartical/config/external.py
+++ b/quartical/config/external.py
@@ -135,7 +135,10 @@ class Outputs(Input):
 @dataclass
 class MadFlags(Input):
     enable: bool = False
-    whiten: bool = True
+    whitening: str = field(
+        default="disabled",
+        metadata=dict(choices=["disabled", "native", "robust"])
+    )
     threshold_bl: float = 5
     threshold_global: float = 10
     max_deviation: float = 10

--- a/quartical/config/helper.py
+++ b/quartical/config/helper.py
@@ -22,7 +22,7 @@ HELP_MSG = f"For full help, use 'goquartical help'. For help with a " \
            f"specific section, use e.g. 'goquartical help='[section1," \
            f"section2]''. Help is available for " \
            f"[{', '.join(HELPSTRINGS.keys())}]. Other command line " \
-           f"utilitites: [goquartical-backup, goquartical-restore]."
+           f"utilities: [goquartical-backup, goquartical-restore]."
 
 
 def populate(typ, help_str, help_dict=None):

--- a/quartical/config/helpstrings.yaml
+++ b/quartical/config/helpstrings.yaml
@@ -131,6 +131,11 @@ output:
 mad_flags:
   enable:
     Enables the MAD flagging routines.
+  whiten:
+    Determines whether the residuals are whitened (multiplied by the square
+    root of the weights) prior to performing MAD flagging. This is recommended
+    when the weights are known to be good. Disabling will do MAD flagging on
+    the unwhitened residuals.
   threshold_bl:
     Multiplicative factor which determines whether or not a chi-squared value
     is considered to deviate significantly from the median of a given baseline.

--- a/quartical/config/helpstrings.yaml
+++ b/quartical/config/helpstrings.yaml
@@ -131,11 +131,13 @@ output:
 mad_flags:
   enable:
     Enables the MAD flagging routines.
-  whiten:
-    Determines whether the residuals are whitened (multiplied by the square
-    root of the weights) prior to performing MAD flagging. This is recommended
-    when the weights are known to be good. Disabling will do MAD flagging on
-    the unwhitened residuals.
+  whitening:
+    Determines whether and how the residuals are whitened (multiplied by the
+    square root of the weights) prior to performing MAD flagging. "native"
+    whitening will use the original weights (specified in the input_ms
+    section). "robust" will use the weights produced when solver.robust=True.
+    "disabled" will result in the MAD estimate being performed on the
+    unwhitened residuals.
   threshold_bl:
     Multiplicative factor which determines whether or not a chi-squared value
     is considered to deviate significantly from the median of a given baseline.

--- a/quartical/config/internal.py
+++ b/quartical/config/internal.py
@@ -57,4 +57,10 @@ def additional_validation(config):
 
     assert not any(store.full_path in ll.full_path for ll in load_stores), msg
 
+    if config.mad_flags.whitening == "robust":
+        assert config.solver.robust, (
+            "mad_flags.whitening specified as robust but solver.robust is "
+            "not enabled."
+        )
+
     return

--- a/quartical/flagging/flagging.py
+++ b/quartical/flagging/flagging.py
@@ -125,8 +125,10 @@ def add_mad_graph(data_xds_list, mad_opts):
 
     for xds in data_xds_list:
         residuals = xds._RESIDUAL.data
-        if mad_opts.whiten:
+        if mad_opts.whitening == "robust":
             weight_col = xds._WEIGHT.data
+        elif mad_opts.whitening == "native":
+            weight_col = xds.WEIGHT.data
         else:
             weight_col = da.ones_like(
                 xds._WEIGHT.data,

--- a/quartical/flagging/flagging.py
+++ b/quartical/flagging/flagging.py
@@ -125,7 +125,13 @@ def add_mad_graph(data_xds_list, mad_opts):
 
     for xds in data_xds_list:
         residuals = xds._RESIDUAL.data
-        weight_col = xds._WEIGHT.data
+        if mad_opts.whiten:
+            weight_col = xds._WEIGHT.data
+        else:
+            weight_col = da.ones_like(
+                xds._WEIGHT.data,
+                name="unity_weights-" + uuid4().hex
+            )
         flag_col = xds.FLAG.data
         ant1_col = xds.ANTENNA1.data
         ant2_col = xds.ANTENNA2.data

--- a/quartical/flagging/flagging_kernels.py
+++ b/quartical/flagging/flagging_kernels.py
@@ -62,14 +62,14 @@ def compute_gbl_mad_and_med(wres, flags):
 
     mad_and_med = np.zeros((1, 1, n_corr, 2), dtype=wres.dtype)
 
-    unflagged_sel = np.where(flags.flatten() == 0)
+    unflagged_sel = np.where(flags.ravel() == 0)
 
     if unflagged_sel[0].size:  # We have unflagged data.
         for c in range(n_corr):
-            gbl_chisq = wres[..., c].flatten()
+            gbl_wres = wres[..., c].ravel()[unflagged_sel]
 
-            gbl_median = np.median(gbl_chisq[unflagged_sel])
-            gbl_mad = np.median(np.abs(gbl_chisq - gbl_median)[unflagged_sel])
+            gbl_median = np.median(gbl_wres)
+            gbl_mad = np.median(np.abs(gbl_wres - gbl_median))
 
             mad_and_med[0, 0, c, 0] = gbl_mad
             mad_and_med[0, 0, c, 1] = gbl_median

--- a/quartical/flagging/flagging_kernels.py
+++ b/quartical/flagging/flagging_kernels.py
@@ -3,11 +3,11 @@ from numba import jit
 
 
 @jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
-def compute_chisq(resid_arr, weights):
+def compute_whitened_residual(resid_arr, weights):
 
     n_row, n_chan, n_corr = resid_arr.shape
 
-    chisq = np.zeros((n_row, n_chan), dtype=resid_arr.real.dtype)
+    wres = np.zeros((n_row, n_chan, n_corr), dtype=resid_arr.real.dtype)
 
     for r in range(n_row):
         for f in range(n_chan):
@@ -17,103 +17,127 @@ def compute_chisq(resid_arr, weights):
                 r_rfc_conj = r_rfc.conjugate()
                 w_rfc = weights[r, f, c]
 
-                chisq[r, f] += (r_rfc_conj * w_rfc * r_rfc).real
+                wres[r, f, c] = np.sqrt((r_rfc_conj * w_rfc * r_rfc).real)
 
-    return chisq
+    return wres
 
 
 @jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
-def compute_bl_mad_and_med(chisq, flags, a1, a2, n_ant):
+def compute_bl_mad_and_med(wres, flags, a1, a2, n_ant):
 
-    mad_and_med = np.zeros((2, n_ant, n_ant), dtype=chisq.dtype)
+    n_corr = wres.shape[-1]
+
+    # TODO: Make this a bl dim array, with computed indices.
+    mad_and_med = np.zeros((1, n_ant, n_ant, n_corr, 2), dtype=wres.dtype)
 
     for a in range(n_ant):
         for b in range(a + 1, n_ant):
 
             bl_sel = \
-                np.where(((a1 == a) & (a2 == b)) | ((a1 == b) & (a2 == a)))
+                np.where(((a1 == a) & (a2 == b)) | ((a1 == b) & (a2 == a)))[0]
 
-            if not bl_sel[0].size:  # Missing baseline.
+            if not bl_sel.size:  # Missing baseline.
                 continue
 
-            bl_chisq = chisq[bl_sel].flatten()
-            bl_flags = flags[bl_sel].flatten()  # No correlation axis.
-
+            bl_flags = flags[bl_sel].ravel()
             unflagged_sel = np.where(bl_flags == 0)
 
-            if unflagged_sel[0].size:
-                bl_median = np.median(bl_chisq[unflagged_sel])
-                bl_mad = np.median(np.abs(bl_chisq - bl_median)[unflagged_sel])
-                mad_and_med[0, a, b] = bl_mad
-                mad_and_med[1, a, b] = bl_median
+            if unflagged_sel[0].size:  # Not fully flagged.
+                for c in range(n_corr):
+
+                    bl_wres = wres[bl_sel, :, c].ravel()
+
+                    bl_median = np.median(bl_wres[unflagged_sel])
+                    bl_mad = \
+                        np.median(np.abs(bl_wres - bl_median)[unflagged_sel])
+                    mad_and_med[0, a, b, c, 0] = bl_mad
+                    mad_and_med[0, a, b, c, 1] = bl_median
 
     return mad_and_med
 
 
 @jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
-def compute_gbl_mad_and_med(chisq, flags):
+def compute_gbl_mad_and_med(wres, flags):
 
-    gbl_chisq = chisq.flatten()
+    n_corr = wres.shape[-1]
+
+    mad_and_med = np.zeros((1, n_corr, 2), dtype=wres.dtype)
+
     unflagged_sel = np.where(flags.flatten() == 0)
 
     if unflagged_sel[0].size:  # We have unflagged data.
-        gbl_median = np.median(gbl_chisq[unflagged_sel])
-        gbl_mad = np.median(np.abs(gbl_chisq - gbl_median)[unflagged_sel])
-    else:
-        gbl_median = 0
-        gbl_mad = 0
+        for c in range(n_corr):
+            gbl_chisq = wres[..., c].flatten()
 
-    return np.array((gbl_mad, gbl_median)).astype(chisq.dtype)
+            gbl_median = np.median(gbl_chisq[unflagged_sel])
+            gbl_mad = np.median(np.abs(gbl_chisq - gbl_median)[unflagged_sel])
+
+            mad_and_med[0, c, 0] = gbl_mad
+            mad_and_med[0, c, 1] = gbl_median
+
+    return mad_and_med
 
 
 @jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
-def compute_mad_flags(chisq, gbl_mad_and_med, bl_mad_and_med, ant1, ant2,
-                      gbl_threshold, bl_threshold, max_deviation):
+def compute_mad_flags(
+    wres,
+    gbl_mad_and_med,
+    bl_mad_and_med,
+    ant1,
+    ant2,
+    gbl_threshold,
+    bl_threshold,
+    max_deviation
+):
 
-    flags = np.zeros_like(chisq, dtype=np.int8)
+    n_row, n_chan, n_corr = wres.shape
 
-    gbl_mad, gbl_med = gbl_mad_and_med
-    bl_mad, bl_med = bl_mad_and_med
-
-    if gbl_mad == 0:  # Indicates that all data was flagged.
-        flags[:] = 1
-        return flags
+    flags = np.zeros((n_row, n_chan), dtype=np.int8)
 
     scale_factor = 1.4826
 
-    gbl_std = scale_factor * gbl_mad  # MAD to standard deviation.
-    gbl_cutoff = gbl_threshold * gbl_std
+    for corr in range(n_corr):
 
-    # This is the MAD estimate of the baseline MAD estimates. We want to use
-    # this to find bad baselines.
-    valid_bl_mad = bl_mad.flatten()[bl_mad.flatten() > 0]
-    valid_bl_mad_median = np.median(valid_bl_mad)
-    bl_mad_mad = np.median(np.abs(valid_bl_mad - valid_bl_mad_median))
+        gbl_mad = gbl_mad_and_med[0, corr, 0]
+        gbl_med = gbl_mad_and_med[0, corr, 1]
+        bl_mad = bl_mad_and_med[0, :, :, corr, 0]
+        bl_med = bl_mad_and_med[0, :, :, corr, 1]
 
-    n_row, n_chan = chisq.shape
-
-    for row in range(n_row):
-
-        a1_m, a2_m = ant1[row], ant2[row]
-
-        mad_pq = bl_mad[a1_m, a2_m]
-        med_pq = bl_med[a1_m, a2_m]
-
-        bl_mad_deviation = np.abs(mad_pq - valid_bl_mad_median)/bl_mad_mad
-
-        if bl_mad_deviation > max_deviation:
-            flags[row] = 1
+        if gbl_mad == 0:  # Indicates that all data was flagged.
+            flags[:] = 1
             continue
 
-        bl_std = scale_factor * mad_pq
-        bl_cutoff = bl_threshold * bl_std
+        gbl_std = scale_factor * gbl_mad  # MAD to standard deviation.
+        gbl_cutoff = gbl_threshold * gbl_std
 
-        for chan in range(n_chan):
+        # This is the MAD estimate of the baseline MAD estimates. We want to
+        # use this to find bad baselines.
+        valid_bl_mad = bl_mad.flatten()[bl_mad.flatten() > 0]
+        valid_bl_mad_median = np.median(valid_bl_mad)
+        bl_mad_mad = np.median(np.abs(valid_bl_mad - valid_bl_mad_median))
 
-            if np.abs(chisq[row, chan] - med_pq) > bl_cutoff:
-                flags[row, chan] = 1
+        for row in range(n_row):
 
-            if np.abs(chisq[row, chan] - gbl_med) > gbl_cutoff:
-                flags[row, chan] = 1
+            a1_m, a2_m = ant1[row], ant2[row]
+
+            mad_pq = bl_mad[a1_m, a2_m]
+            med_pq = bl_med[a1_m, a2_m]
+
+            bl_mad_deviation = np.abs(mad_pq - valid_bl_mad_median)/bl_mad_mad
+
+            if bl_mad_deviation > max_deviation:
+                flags[row] = 1
+                continue
+
+            bl_std = scale_factor * mad_pq
+            bl_cutoff = bl_threshold * bl_std
+
+            for chan in range(n_chan):
+
+                if np.abs(wres[row, chan, corr] - med_pq) > bl_cutoff:
+                    flags[row, chan] = 1
+
+                if np.abs(wres[row, chan, corr] - gbl_med) > gbl_cutoff:
+                    flags[row, chan] = 1
 
     return flags

--- a/quartical/flagging/flagging_kernels.py
+++ b/quartical/flagging/flagging_kernels.py
@@ -7,17 +7,16 @@ def compute_whitened_residual(resid_arr, weights):
 
     n_row, n_chan, n_corr = resid_arr.shape
 
-    wres = np.zeros((n_row, n_chan, n_corr), dtype=resid_arr.real.dtype)
+    wres = np.zeros((n_row, n_chan, n_corr), dtype=resid_arr.dtype)
 
     for r in range(n_row):
         for f in range(n_chan):
             for c in range(n_corr):
 
                 r_rfc = resid_arr[r, f, c]
-                r_rfc_conj = r_rfc.conjugate()
                 w_rfc = weights[r, f, c]
 
-                wres[r, f, c] = np.sqrt((r_rfc_conj * w_rfc * r_rfc).real)
+                wres[r, f, c] = np.sqrt(w_rfc) * r_rfc
 
     return wres
 

--- a/quartical/flagging/flagging_kernels.py
+++ b/quartical/flagging/flagging_kernels.py
@@ -28,7 +28,7 @@ def compute_bl_mad_and_med(wres, flags, a1, a2, n_ant):
     n_corr = wres.shape[-1]
 
     # TODO: Make this a bl dim array, with computed indices.
-    mad_and_med = np.zeros((1, n_ant, n_ant, n_corr, 2), dtype=wres.dtype)
+    mad_and_med = np.zeros((1, 1, n_ant, n_ant, n_corr, 2), dtype=wres.dtype)
 
     for a in range(n_ant):
         for b in range(a + 1, n_ant):
@@ -50,8 +50,8 @@ def compute_bl_mad_and_med(wres, flags, a1, a2, n_ant):
                     bl_median = np.median(bl_wres[unflagged_sel])
                     bl_mad = \
                         np.median(np.abs(bl_wres - bl_median)[unflagged_sel])
-                    mad_and_med[0, a, b, c, 0] = bl_mad
-                    mad_and_med[0, a, b, c, 1] = bl_median
+                    mad_and_med[0, 0, a, b, c, 0] = bl_mad
+                    mad_and_med[0, 0, a, b, c, 1] = bl_median
 
     return mad_and_med
 
@@ -61,7 +61,7 @@ def compute_gbl_mad_and_med(wres, flags):
 
     n_corr = wres.shape[-1]
 
-    mad_and_med = np.zeros((1, n_corr, 2), dtype=wres.dtype)
+    mad_and_med = np.zeros((1, 1, n_corr, 2), dtype=wres.dtype)
 
     unflagged_sel = np.where(flags.flatten() == 0)
 
@@ -72,8 +72,8 @@ def compute_gbl_mad_and_med(wres, flags):
             gbl_median = np.median(gbl_chisq[unflagged_sel])
             gbl_mad = np.median(np.abs(gbl_chisq - gbl_median)[unflagged_sel])
 
-            mad_and_med[0, c, 0] = gbl_mad
-            mad_and_med[0, c, 1] = gbl_median
+            mad_and_med[0, 0, c, 0] = gbl_mad
+            mad_and_med[0, 0, c, 1] = gbl_median
 
     return mad_and_med
 
@@ -98,10 +98,10 @@ def compute_mad_flags(
 
     for corr in range(n_corr):
 
-        gbl_mad = gbl_mad_and_med[0, corr, 0]
-        gbl_med = gbl_mad_and_med[0, corr, 1]
-        bl_mad = bl_mad_and_med[0, :, :, corr, 0]
-        bl_med = bl_mad_and_med[0, :, :, corr, 1]
+        gbl_mad = gbl_mad_and_med[0, 0, corr, 0]
+        gbl_med = gbl_mad_and_med[0, 0, corr, 1]
+        bl_mad = bl_mad_and_med[0, 0, :, :, corr, 0]
+        bl_med = bl_mad_and_med[0, 0, :, :, corr, 1]
 
         if gbl_mad == 0:  # Indicates that all data was flagged.
             flags[:] = 1


### PR DESCRIPTION
The MAD flagging code was some of my first dask code. As such, it was very messy and probably slightly incorrect. This is not a complete fix - that will require a full rewrite - but this should improve its behaviour/make it more correct. At present I am using the whitened residuals (`np.sqrt(r*r.conj()*W)`) in the MAD flagger but it is possible the `np.sqrt` can be omitted. It is now possible to disable whitening (the multiplication by W in the above expression) for cases where the weights are known to be incorrect. 

@landmanbester feel free to give it a test drive.