### PR TITLE
Disable P jones settings by default.

### DIFF
--- a/quartical/config/external.py
+++ b/quartical/config/external.py
@@ -85,7 +85,7 @@ class ModelInputs(Input):
     )
     invert_uvw: bool = True
     source_chunks: int = 500
-    apply_p_jones: bool = True
+    apply_p_jones: bool = False
 
     def __post_init__(self):
         self.validate_choice_fields()
@@ -107,7 +107,7 @@ class Outputs(Input):
     )
     columns: Optional[List[str]] = None
     flags: bool = True
-    apply_p_jones_inv: bool = True
+    apply_p_jones_inv: bool = False
     subtract_directions: Optional[List[int]] = None
     net_gains: Optional[List[Any]] = None
 

--- a/quartical/data_handling/model_handler.py
+++ b/quartical/data_handling/model_handler.py
@@ -41,7 +41,18 @@ def add_model_graph(data_xds_list, parangle_xds_list, model_vis_recipe,
     # which require them. P Jones is applied to predicted components
     # internally, so we only need to consider model columns for now.
 
+    n_corr = {xds.dims["corr"] for xds in data_xds_list}.pop()
+
     if model_opts.apply_p_jones:
+        # NOTE: Applying parallactic angle when there are fewer than four
+        # correlations is problematic for linear feeds as it amounts to
+        # rotating information into correlations which are not present i.e.
+        # it is not reversible. Thus, we elect not to support it.
+        if n_corr != 4:
+            raise ValueError(
+                "input_model.apply_p_jones is not supported for data with "
+                "less than four correlations. Please disable this setting."
+            )
         model_columns = model_vis_recipe.ingredients.model_columns
         data_xds_list = apply_parangles(data_xds_list,
                                         parangle_xds_list,

--- a/quartical/data_handling/model_handler.py
+++ b/quartical/data_handling/model_handler.py
@@ -46,12 +46,13 @@ def add_model_graph(data_xds_list, parangle_xds_list, model_vis_recipe,
     if model_opts.apply_p_jones:
         # NOTE: Applying parallactic angle when there are fewer than four
         # correlations is problematic for linear feeds as it amounts to
-        # rotating information into correlations which are not present i.e.
-        # it is not reversible. Thus, we elect not to support it.
+        # rotating information to/from correlations which are not present i.e.
+        # it is not reversible. We support it for input models but warn the
+        # user that it is not a good idea.
         if n_corr != 4:
-            raise ValueError(
-                "input_model.apply_p_jones is not supported for data with "
-                "less than four correlations. Please disable this setting."
+            logger.warning(
+                "input_model.apply_p_jones is not recommended for data with "
+                "less than four correlations. Proceed with caution."
             )
         model_columns = model_vis_recipe.ingredients.model_columns
         data_xds_list = apply_parangles(data_xds_list,
@@ -114,9 +115,10 @@ def add_model_graph(data_xds_list, parangle_xds_list, model_vis_recipe,
                 # direction only.
 
                 if len(in_a) > 1 and len(in_b) > 1:
-                    raise(ValueError("Model recipes do not support add or "
-                                     "subtract operations between two "
-                                     "direction-dependent inputs."))
+                    raise ValueError(
+                        "Model recipes do not support add or subtract "
+                        "operations between two direction-dependent inputs."
+                    )
                 elif len(in_a) > len(in_b):
                     result = [op(in_a[0], in_b[0]), *in_a[1:]]
                 elif len(in_a) < len(in_b):

--- a/quartical/data_handling/ms_handler.py
+++ b/quartical/data_handling/ms_handler.py
@@ -394,7 +394,7 @@ def postprocess_xds_list(data_xds_list, parangle_xds_list, output_opts):
     if output_opts.apply_p_jones_inv:
         # NOTE: Applying parallactic angle when there are fewer than four
         # correlations is problematic for linear feeds as it amounts to
-        # rotating information into correlations which are not present i.e.
+        # rotating information to/from correlations which are not present i.e.
         # it is not reversible. Thus, we elect not to support it.
         if n_corr != 4:
             raise ValueError(

--- a/quartical/data_handling/ms_handler.py
+++ b/quartical/data_handling/ms_handler.py
@@ -389,7 +389,18 @@ def postprocess_xds_list(data_xds_list, parangle_xds_list, output_opts):
             data with postprocessing operations applied.
     """
 
+    n_corr = {xds.dims["corr"] for xds in data_xds_list}.pop()
+
     if output_opts.apply_p_jones_inv:
+        # NOTE: Applying parallactic angle when there are fewer than four
+        # correlations is problematic for linear feeds as it amounts to
+        # rotating information into correlations which are not present i.e.
+        # it is not reversible. Thus, we elect not to support it.
+        if n_corr != 4:
+            raise ValueError(
+                "output.apply_p_jones_inv is not supported for data with "
+                "less than four correlations. Please disable this setting."
+            )
         derot_vars = ["_RESIDUAL", "_CORRECTED_DATA", "_CORRECTED_RESIDUAL"]
 
         output_data_xds_list = apply_parangles(data_xds_list,


### PR DESCRIPTION
Only support P jones application when four correlations are present. Fixes #215.