### PR TITLE
Change approach for identifying missing columns.

### DIFF
--- a/quartical/data_handling/ms_handler.py
+++ b/quartical/data_handling/ms_handler.py
@@ -99,7 +99,7 @@ def read_xds_list(model_columns, ms_opts):
             table_schema=["MS", {**schema}])
     except RuntimeError as e:
         raise RuntimeError(
-            f"Invalid/missing column specified. Unerlying error: {e}."
+            f"Invalid/missing column specified. Underlying error: {e}."
         ) from e
 
     spw_xds_list = xds_from_storage_table(


### PR DESCRIPTION
This should fix #226 as reported by @bennahugo. The problem was originally caused by relying on `xds_from_storage_ms` to produce a complete list of column names. This is unreliable as columns can be omitted if they have an invalid exemplar row (@bennahugo's case). This PR removes the problematic assert and replaces it with a `try except` which relies on the underlying daskms routines to raise sensible error messages which we can augment for readability.