### PR TITLE
Add support for identity model.

### DIFF
--- a/quartical/config/external.py
+++ b/quartical/config/external.py
@@ -73,7 +73,7 @@ class MSInputs(Input):
 
 @dataclass
 class ModelInputs(Input):
-    recipe: str = "???"
+    recipe: Optional[str] = None
     beam: Optional[str] = None
     beam_l_axis: str = field(
         default="X",

--- a/quartical/config/helpstrings.yaml
+++ b/quartical/config/helpstrings.yaml
@@ -67,7 +67,8 @@ input_model:
     Combining all of the above it is possible to do things like
     "COL1~LSM1:LSM1@dE" which will create a model with multiple
     directions, the first given by COL1 minus LSM1 and the remainder given
-    given by the dE tagged clusters in LSM1.
+    given by the dE tagged clusters in LSM1. Leaving this value unset
+    (the default) will use an identity model.
   beam:
     Path to beams. Apply beams during predict if specified eg.
     'beam_$(corr)_$(reim).fits' or 'beam_$(CORR)_$(REIM).fits'.

--- a/quartical/config/preprocess.py
+++ b/quartical/config/preprocess.py
@@ -23,6 +23,11 @@ class Recipe:
     instructions: Dict[int, List[Any]]
 
 
+@dataclass
+class IdentityRecipe(Recipe):
+    pass
+
+
 def transcribe_recipe(user_recipe):
     """Interpret the model recipe string.
 
@@ -35,6 +40,12 @@ def transcribe_recipe(user_recipe):
     Returns:
         model_Recipe: A Recipe object.
     """
+
+    if user_recipe is None:
+        logger.warning(
+            "input_model.recipe was not supplied. Assuming identity model."
+        )
+        return IdentityRecipe(Ingredients(set(), set()), dict())
 
     model_columns = set()
     sky_models = set()

--- a/quartical/data_handling/model_handler.py
+++ b/quartical/data_handling/model_handler.py
@@ -1,12 +1,20 @@
 # -*- coding: utf-8 -*-
 import dask.array as da
+import numpy as np
 from quartical.data_handling.predict import predict
 from quartical.data_handling.angles import apply_parangles
+from quartical.config.preprocess import IdentityRecipe, Ingredients
+from quartical.utils.array import flat_ident_like
 from loguru import logger  # noqa
 
 
-def add_model_graph(data_xds_list, parangle_xds_list, model_vis_recipe,
-                    ms_path, model_opts):
+def add_model_graph(
+    data_xds_list,
+    parangle_xds_list,
+    model_vis_recipe,
+    ms_path,
+    model_opts
+):
     """Creates the graph necessary to produce a model per xds.
 
     Given a list of input xarray data sets and the options, constructs a graph
@@ -35,6 +43,11 @@ def add_model_graph(data_xds_list, parangle_xds_list, model_vis_recipe,
                                   model_opts)
     else:
         predict_schemes = [{}]*len(data_xds_list)
+
+    # Special case: in the event that we have an IdentityRecipe, modify the
+    # datasets and model appropriately.
+    if isinstance(model_vis_recipe, IdentityRecipe):
+        data_xds_list, model_vis_recipe = assign_identity_model(data_xds_list)
 
     # NOTE: At this point we are ready to construct the model array. First,
     # however, we need to apply parallactic angle corrections to model columns
@@ -142,3 +155,60 @@ def add_model_graph(data_xds_list, parangle_xds_list, model_vis_recipe,
         model_xds_list.append(modified_xds)
 
     return model_xds_list
+
+
+def assign_identity_model(data_xds_list):
+    """Given dataset list, creates recipe and assigns an identity model.
+
+    This is a special case where we have no input model and simply want to use
+    the identity. This is common when constraining phase solutions on a
+    calibrator.
+
+    Args:
+        data_xds_list: A list of xarray.Datasets objects containing MS data.
+
+    Returns:
+        data_xds_list: A list of xarray.Datasets with new model assigned.
+        recipe: A modified Recipe object consistent with this case.
+    """
+
+    ingredients = Ingredients({"__IDENT__"}, set())
+    instructions = {0: ["__IDENT__"]}
+
+    recipe = IdentityRecipe(ingredients, instructions)
+
+    model_dims = [
+        (
+            xds.dims['row'],
+            xds.dims['chan'],
+            xds.dims['corr']
+        )
+        for xds in data_xds_list
+    ]
+
+    model_chunks = [
+        (
+            xds.chunks['row'],
+            xds.chunks['chan'],
+            xds.chunks['corr']
+        )
+        for xds in data_xds_list
+    ]
+
+    data_xds_list = [
+        xds.assign(
+            {
+                "__IDENT__": (
+                    ("row", "chan", "corr"),
+                    flat_ident_like(
+                        da.empty(dims, chunks=chunks, dtype=np.complex64)
+                    )
+                )
+            }
+        )
+        for xds, dims, chunks in zip(
+            data_xds_list, model_dims, model_chunks
+        )
+    ]
+
+    return data_xds_list, recipe

--- a/quartical/executor.py
+++ b/quartical/executor.py
@@ -108,11 +108,13 @@ def _execute(exitstack):
     parangle_xds_list = make_parangle_xds_list(ms_opts.path, data_xds_list)
 
     # A list of xdss onto which appropriate model data has been assigned.
-    data_xds_list = add_model_graph(data_xds_list,
-                                    parangle_xds_list,
-                                    model_vis_recipe,
-                                    ms_opts.path,
-                                    model_opts)
+    data_xds_list = add_model_graph(
+        data_xds_list,
+        parangle_xds_list,
+        model_vis_recipe,
+        ms_opts.path,
+        model_opts
+    )
 
     stats_xds_list = make_stats_xds_list(data_xds_list)
 

--- a/quartical/utils/array.py
+++ b/quartical/utils/array.py
@@ -1,0 +1,47 @@
+import numpy as np
+import dask.array as da
+from uuid import uuid4
+
+
+def flat_ident_like(arr):
+    """Given a dask.array, returns an equivalent "identity" array.
+
+    An identity array is identitiy in its trailing dimension. This is a little
+    unusual but comes up consistently when dealing with the measurement set.
+
+    Args:
+        arr: A dask.array with a given shape, dtype and chunking.
+
+    Returns:
+        A "identity" dask.array with identical shape, dtype and chunking. 
+    """
+
+    if arr.shape[-1] not in (1, 2, 4):
+        raise ValueError(
+            "flat_ident_like only supports trailing dims of 1, 2 and 4."
+        )
+
+    def _flat_ident_like(chunk):
+        out = np.zeros_like(chunk)
+
+        last_dim = chunk.shape[-1]
+
+        if last_dim == 4:
+            out[..., (0, 3)] = 1
+        elif last_dim in (1, 2):
+            out[:] = 1
+        else:
+            raise ValueError(
+                "flat_ident_like only supports trailing dims of 1, 2 and 4."
+            )
+
+        return out
+
+    dim_str = [f"d{i}" for i in range(arr.ndim)]
+
+    return da.blockwise(
+        _flat_ident_like, dim_str,
+        arr, dim_str,
+        dtype=arr.dtype,
+        name="flat_ident_like-" + uuid4().hex
+    )


### PR DESCRIPTION
Fixes #222 (adds). `input_model.recipe` will no longer be a mandatory argument. Instead, if left unspecified it will default to an identity model. A warning will be logged to protect users who end up in this situation inadvertently. 