### PR TITLE
Add proper leakage term (unity diagonal).

### DIFF
--- a/quartical/config/external.py
+++ b/quartical/config/external.py
@@ -202,7 +202,8 @@ class Gain(Input):
                                "phase",
                                "tec",
                                "rotation_measure",
-                               "crosshand_phase"])
+                               "crosshand_phase",
+                               "leakage"])
     )
     solve_per: str = field(
         default="antenna",

--- a/quartical/gains/__init__.py
+++ b/quartical/gains/__init__.py
@@ -5,6 +5,7 @@ from quartical.gains.delay import Delay
 from quartical.gains.tec import TEC
 from quartical.gains.rotation_measure import RotationMeasure
 from quartical.gains.crosshand_phase import CrosshandPhase
+from quartical.gains.leakage import Leakage
 
 
 TERM_TYPES = {"complex": Complex,
@@ -14,4 +15,5 @@ TERM_TYPES = {"complex": Complex,
               "delay": Delay,
               "tec": TEC,
               "rotation_measure": RotationMeasure,
-              "crosshand_phase": CrosshandPhase}
+              "crosshand_phase": CrosshandPhase,
+              "leakage": Leakage}

--- a/quartical/gains/leakage/__init__.py
+++ b/quartical/gains/leakage/__init__.py
@@ -1,0 +1,34 @@
+from quartical.gains.gain import Gain, gain_spec_tup
+from quartical.gains.leakage.kernel import leakage_solver, leakage_args
+
+
+class Leakage(Gain):
+
+    solver = leakage_solver
+    term_args = leakage_args
+
+    def __init__(self, term_name, term_opts, data_xds, coords, tipc, fipc):
+
+        Gain.__init__(self, term_name, term_opts, data_xds, coords, tipc, fipc)
+
+        if self.n_corr != 4:
+            raise ValueError(
+                "Leakage terms are only supported for 4 correlation data."
+            )
+
+        self.n_ppa = 0
+        self.gain_chunk_spec = gain_spec_tup(self.n_tipc_g,
+                                             self.n_fipc_g,
+                                             (self.n_ant,),
+                                             (self.n_dir,),
+                                             (self.n_corr,))
+        self.gain_axes = ("gain_t", "gain_f", "ant", "dir", "corr")
+
+    def make_xds(self):
+
+        xds = Gain.make_xds(self)
+
+        xds = xds.assign_attrs({"GAIN_SPEC": self.gain_chunk_spec,
+                                "GAIN_AXES": self.gain_axes})
+
+        return xds

--- a/quartical/gains/leakage/kernel.py
+++ b/quartical/gains/leakage/kernel.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+from numba import generated_jit
+from quartical.utils.numba import coerce_literal
+from quartical.gains.general.generics import (native_intermediaries,
+                                              upsampled_itermediaries,
+                                              per_array_jhj_jhr,
+                                              resample_solints,
+                                              downsample_jhj_jhr)
+from quartical.gains.general.flagging import (flag_intermediaries,
+                                              update_gain_flags,
+                                              finalize_gain_flags,
+                                              apply_gain_flags)
+from quartical.gains.general.convenience import get_extents
+import quartical.gains.general.factories as factories
+from quartical.gains.complex.kernel import (get_jhj_dims_factory,
+                                            compute_jhj_jhr,
+                                            compute_update)
+
+from collections import namedtuple
+
+
+# This can be done without a named tuple now. TODO: Add unpacking to
+# constructor.
+stat_fields = {"conv_iters": np.int64,
+               "conv_perc": np.float64}
+
+term_conv_info = namedtuple("term_conv_info", " ".join(stat_fields.keys()))
+
+leakage_args = namedtuple("leakage_args", ())
+
+
+@generated_jit(nopython=True,
+               fastmath=True,
+               parallel=False,
+               cache=True,
+               nogil=True)
+def leakage_solver(base_args, term_args, meta_args, corr_mode):
+
+    coerce_literal(leakage_solver, ["corr_mode"])
+
+    get_jhj_dims = get_jhj_dims_factory(corr_mode)
+
+    def impl(base_args, term_args, meta_args, corr_mode):
+
+        gains = base_args.gains
+        gain_flags = base_args.gain_flags
+
+        active_term = meta_args.active_term
+        max_iter = meta_args.iters
+        solve_per = meta_args.solve_per
+        dd_term = meta_args.dd_term
+        n_thread = meta_args.threads
+
+        active_gain = gains[active_term]
+        active_gain_flags = gain_flags[active_term]
+
+        # Set up some intemediaries used for flagging. TODO: Move?
+        km1_gain = active_gain.copy()
+        km1_abs2_diffs = np.zeros_like(active_gain_flags, dtype=np.float64)
+        abs2_diffs_trend = np.zeros_like(active_gain_flags, dtype=np.float64)
+        flag_imdry = \
+            flag_intermediaries(km1_gain, km1_abs2_diffs, abs2_diffs_trend)
+
+        # Set up some intemediaries used for solving.
+        complex_dtype = active_gain.dtype
+        gain_shape = active_gain.shape
+
+        active_t_map_g = base_args.t_map_arr[0, :, active_term]
+        active_f_map_g = base_args.f_map_arr[0, :, active_term]
+
+        # Create more work to do in paralllel when needed, else no-op.
+        resampler = resample_solints(active_t_map_g, gain_shape, n_thread)
+
+        # Determine the starts and stops of the rows and channels associated
+        # with each solution interval.
+        extents = get_extents(resampler.upsample_t_map, active_f_map_g)
+
+        upsample_shape = resampler.upsample_shape
+        upsampled_jhj = np.empty(get_jhj_dims(upsample_shape),
+                                 dtype=complex_dtype)
+        upsampled_jhr = np.empty(upsample_shape, dtype=complex_dtype)
+        jhj = upsampled_jhj[:gain_shape[0]]
+        jhr = upsampled_jhr[:gain_shape[0]]
+        update = np.zeros(gain_shape, dtype=complex_dtype)
+
+        upsampled_imdry = upsampled_itermediaries(upsampled_jhj, upsampled_jhr)
+        native_imdry = native_intermediaries(jhj, jhr, update)
+
+        for loop_idx in range(max_iter):
+
+            compute_jhj_jhr(base_args,
+                            term_args,
+                            meta_args,
+                            upsampled_imdry,
+                            extents,
+                            corr_mode)
+
+            if resampler.active:
+                downsample_jhj_jhr(upsampled_imdry, resampler.downsample_t_map)
+
+            if solve_per == "array":
+                per_array_jhj_jhr(native_imdry)
+
+            compute_update(native_imdry,
+                           corr_mode)
+
+            finalize_update(base_args,
+                            term_args,
+                            meta_args,
+                            native_imdry,
+                            loop_idx,
+                            corr_mode)
+
+            # Check for gain convergence. Produced as a side effect of
+            # flagging. The converged percentage is based on unflagged
+            # intervals.
+            conv_perc = update_gain_flags(base_args,
+                                          term_args,
+                                          meta_args,
+                                          flag_imdry,
+                                          loop_idx,
+                                          corr_mode)
+
+            if conv_perc >= meta_args.stop_frac:
+                break
+
+        # NOTE: Removes soft flags and flags points which have bad trends.
+        finalize_gain_flags(base_args,
+                            meta_args,
+                            flag_imdry,
+                            corr_mode)
+
+        # Call this one last time to ensure points flagged by finialize are
+        # propagated (in the DI case).
+        if not dd_term:
+            apply_gain_flags(base_args,
+                             meta_args)
+
+        return native_imdry.jhj, term_conv_info(loop_idx + 1, conv_perc)
+
+    return impl
+
+
+@generated_jit(nopython=True, fastmath=True, parallel=False, cache=True,
+               nogil=True)
+def finalize_update(base_args, term_args, meta_args, native_imdry, loop_idx,
+                    corr_mode):
+
+    set_identity = factories.set_identity_factory(corr_mode)
+
+    def impl(base_args, term_args, meta_args, native_imdry, loop_idx,
+             corr_mode):
+
+        dd_term = meta_args.dd_term
+        active_term = meta_args.active_term
+
+        gain = base_args.gains[active_term]
+        gain_flags = base_args.gain_flags[active_term]
+
+        update = native_imdry.update
+
+        n_tint, n_fint, n_ant, n_dir, n_corr = gain.shape
+
+        for ti in range(n_tint):
+            for fi in range(n_fint):
+                for a in range(n_ant):
+                    for d in range(n_dir):
+
+                        g = gain[ti, fi, a, d]
+                        fl = gain_flags[ti, fi, a, d]
+                        upd = update[ti, fi, a, d]
+
+                        upd[0] = 0
+                        upd[3] = 0
+
+                        if fl == 1:
+                            set_identity(g)
+                        elif dd_term or (loop_idx % 2 == 0):
+                            upd /= 2
+                            g += upd
+                        else:
+                            g += upd
+
+    return impl


### PR DESCRIPTION
In preparation for further polcal experiments, it is useful to have an explicit leakage term. Practically, this just a complex 2x2 term which discards its on-diagonal updates. This is important as otherwise the leakage term will absorb errors which should instead be in the time-dependent gain/bandpass. This should also make plotting the leakages simpler as they are simply the off-diagonal terms of the D matrix. 

Edit: Note that no additional tests have been added as this terms is functionally identical to a 2x2 complex term and is therefore tested implicitly.