### PR TITLE
Add support for interpolation in only amp or phase i.e. ignore the non-interpolated part.

### DIFF
--- a/quartical/config/external.py
+++ b/quartical/config/external.py
@@ -219,7 +219,9 @@ class Gain(Input):
     interp_mode: str = field(
         default="reim",
         metadata=dict(choices=["reim",
-                               "ampphase"])
+                               "ampphase",
+                               "amp",
+                               "phase"])
     )
     interp_method: str = field(
         default="2dlinear",


### PR DESCRIPTION
@landmanbester Hopefully does what it says - this was a simple enough hack. If `term.interp_mode` is set to `amp`, the interpolated gains will have zero phase. If `term.interp_mode` is set to `phase`, the interpolated gains will have unity amplitude. Note that these modes are only suitable for diagonal terms. 