### PR TITLE
Add a pure delay solver (no offset).

### DIFF
--- a/quartical/config/external.py
+++ b/quartical/config/external.py
@@ -199,6 +199,7 @@ class Gain(Input):
                                "diag_complex",
                                "amplitude",
                                "delay",
+                               "pure_delay",
                                "phase",
                                "tec",
                                "rotation_measure",

--- a/quartical/gains/__init__.py
+++ b/quartical/gains/__init__.py
@@ -1,7 +1,7 @@
 from quartical.gains.complex import Complex, DiagComplex
 from quartical.gains.amplitude import Amplitude
 from quartical.gains.phase import Phase
-from quartical.gains.delay import Delay
+from quartical.gains.delay import Delay, PureDelay
 from quartical.gains.tec import TEC
 from quartical.gains.rotation_measure import RotationMeasure
 from quartical.gains.crosshand_phase import CrosshandPhase
@@ -13,6 +13,7 @@ TERM_TYPES = {"complex": Complex,
               "amplitude": Amplitude,
               "phase": Phase,
               "delay": Delay,
+              "pure_delay": PureDelay,
               "tec": TEC,
               "rotation_measure": RotationMeasure,
               "crosshand_phase": CrosshandPhase,

--- a/quartical/gains/delay/__init__.py
+++ b/quartical/gains/delay/__init__.py
@@ -1,5 +1,6 @@
 from quartical.gains.gain import Gain, gain_spec_tup, param_spec_tup
 from quartical.gains.delay.kernel import delay_solver, delay_args
+from quartical.gains.delay.pure_kernel import pure_delay_solver
 import numpy as np
 
 
@@ -183,3 +184,20 @@ class Delay(Gain):
 
                 if n_corr > 1:
                     gain[ut, f, :, :, -1] = np.exp(cf * param[ut, fm, :, :, 3])
+
+
+class PureDelay(Delay):
+
+    solver = pure_delay_solver
+
+    def __init__(self, term_name, term_opts, data_xds, coords, tipc, fipc):
+
+        Delay.__init__(
+            self,
+            term_name,
+            term_opts,
+            data_xds,
+            coords,
+            tipc,
+            fipc
+        )

--- a/quartical/gains/delay/pure_kernel.py
+++ b/quartical/gains/delay/pure_kernel.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+from numba import generated_jit
+from quartical.utils.numba import coerce_literal
+from quartical.gains.general.generics import (
+    native_intermediaries,
+    upsampled_itermediaries,
+    per_array_jhj_jhr,
+    resample_solints,
+    downsample_jhj_jhr
+)
+from quartical.gains.general.flagging import (
+    flag_intermediaries,
+    update_gain_flags,
+    finalize_gain_flags,
+    apply_gain_flags,
+    update_param_flags
+)
+from quartical.gains.general.convenience import (
+    get_extents
+)
+from quartical.gains.delay.kernel import (
+    compute_jhj_jhr,
+    compute_update,
+    finalize_update
+)
+from collections import namedtuple
+
+
+# This can be done without a named tuple now. TODO: Add unpacking to
+# constructor.
+stat_fields = {"conv_iters": np.int64,
+               "conv_perc": np.float64}
+
+term_conv_info = namedtuple("term_conv_info", " ".join(stat_fields.keys()))
+
+delay_args = namedtuple(
+    "delay_args",
+    (
+        "params",
+        "param_flags",
+        "chan_freqs",
+        "t_bin_arr"
+    )
+)
+
+
+def get_identity_params(corr_mode):
+
+    if corr_mode.literal_value in (2, 4):
+        return np.zeros((4,), dtype=np.float64)
+    elif corr_mode.literal_value == 1:
+        return np.zeros((2,), dtype=np.float64)
+    else:
+        raise ValueError("Unsupported number of correlations.")
+
+
+@generated_jit(nopython=True,
+               fastmath=True,
+               parallel=False,
+               cache=True,
+               nogil=True)
+def pure_delay_solver(base_args, term_args, meta_args, corr_mode):
+
+    coerce_literal(pure_delay_solver, ["corr_mode"])
+
+    identity_params = get_identity_params(corr_mode)
+
+    def impl(base_args, term_args, meta_args, corr_mode):
+
+        gains = base_args.gains
+        gain_flags = base_args.gain_flags
+
+        active_term = meta_args.active_term
+        max_iter = meta_args.iters
+        solve_per = meta_args.solve_per
+        dd_term = meta_args.dd_term
+        n_thread = meta_args.threads
+
+        active_gain = gains[active_term]
+        active_gain_flags = gain_flags[active_term]
+        active_params = term_args.params[active_term]
+
+        # Set up some intemediaries used for flagging.
+        km1_gain = active_gain.copy()
+        km1_abs2_diffs = np.zeros_like(active_gain_flags, dtype=np.float64)
+        abs2_diffs_trend = np.zeros_like(active_gain_flags, dtype=np.float64)
+        flag_imdry = \
+            flag_intermediaries(km1_gain, km1_abs2_diffs, abs2_diffs_trend)
+
+        # Set up some intemediaries used for solving.
+        real_dtype = active_gain.real.dtype
+        param_shape = active_params.shape
+
+        active_t_map_g = base_args.t_map_arr[0, :, active_term]
+        active_f_map_p = base_args.f_map_arr[1, :, active_term]
+
+        # Create more work to do in paralllel when needed, else no-op.
+        resampler = resample_solints(active_t_map_g, param_shape, n_thread)
+
+        # Determine the starts and stops of the rows and channels associated
+        # with each solution interval.
+        extents = get_extents(resampler.upsample_t_map, active_f_map_p)
+
+        upsample_shape = resampler.upsample_shape
+        upsampled_jhj = np.empty(upsample_shape + (upsample_shape[-1],),
+                                 dtype=real_dtype)
+        upsampled_jhr = np.empty(upsample_shape, dtype=real_dtype)
+        jhj = upsampled_jhj[:param_shape[0]]
+        jhr = upsampled_jhr[:param_shape[0]]
+        update = np.zeros(param_shape, dtype=real_dtype)
+
+        upsampled_imdry = upsampled_itermediaries(upsampled_jhj, upsampled_jhr)
+        native_imdry = native_intermediaries(jhj, jhr, update)
+
+        scaled_cf = term_args.chan_freqs.copy()  # Don't mutate.
+        min_freq = np.min(scaled_cf)
+        scaled_cf /= min_freq  # Scale freqs to avoid precision.
+        active_params[..., 1::2] *= min_freq  # Scale delay consistently.
+        scaled_cf *= 2*np.pi  # Introduce 2pi here - neglect everywhere else.
+
+        for loop_idx in range(max_iter):
+
+            compute_jhj_jhr(base_args,
+                            term_args,
+                            meta_args,
+                            upsampled_imdry,
+                            extents,
+                            scaled_cf,
+                            corr_mode)
+
+            if resampler.active:
+                downsample_jhj_jhr(upsampled_imdry, resampler.downsample_t_map)
+
+            if solve_per == "array":
+                per_array_jhj_jhr(native_imdry)
+
+            compute_update(native_imdry,
+                           corr_mode)
+
+            # Minor hack which prevents offsets from being updated. TODO:
+            # There has to be a neater way to integrate this into the delay
+            # solver.
+            native_imdry.update[..., ::2] = 0
+
+            finalize_update(base_args,
+                            term_args,
+                            meta_args,
+                            native_imdry,
+                            scaled_cf,
+                            loop_idx,
+                            corr_mode)
+
+            # Check for gain convergence. Produced as a side effect of
+            # flagging. The converged percentage is based on unflagged
+            # intervals.
+            conv_perc = update_gain_flags(base_args,
+                                          term_args,
+                                          meta_args,
+                                          flag_imdry,
+                                          loop_idx,
+                                          corr_mode,
+                                          numbness=1e9)
+
+            # Propagate gain flags to parameter flags.
+            update_param_flags(base_args,
+                               term_args,
+                               meta_args,
+                               identity_params)
+
+            if conv_perc >= meta_args.stop_frac:
+                break
+
+        # NOTE: Removes soft flags and flags points which have bad trends.
+        finalize_gain_flags(base_args,
+                            meta_args,
+                            flag_imdry,
+                            corr_mode)
+
+        # Call this one last time to ensure points flagged by finialize are
+        # propagated (in the DI case).
+        if not dd_term:
+            apply_gain_flags(base_args,
+                             meta_args)
+
+        active_params[..., 1::2] /= min_freq  # Undo scaling for SI units.
+
+        return native_imdry.jhj, term_conv_info(loop_idx + 1, conv_perc)
+
+    return impl


### PR DESCRIPTION
@landmanbester As it says on the label. Set `term.type=pure_delay`. I do not love this naming convention but will wait till a later release to replace it with something more explicit as I do not want to change the existing behaviour of `term.type=delay`. At present this will be no faster than a `delay` term as I am simply discarding the offsets on each iteration. Ultimately it may be worth writing a special code path which does less work but I don't think it is a priority.