### PR TITLE
Allow for multi-component spectral indices.

### DIFF
--- a/quartical/data_handling/predict.py
+++ b/quartical/data_handling/predict.py
@@ -450,6 +450,9 @@ def predict(data_xds_list, model_vis_recipe, ms_path, model_opts):
             extras["beam_lm_extents"] = lm_ext
             extras["beam_freq_map"] = freq_map
 
+        # TODO: This needs to be detected/configurable.
+        # extras["spi_base"] = "log10"
+
         model_vis = defaultdict(list)
 
         # Generate visibility expressions per model, per direction for each


### PR DESCRIPTION
@francescaLoi This should (hopefully) fix the problem you encountered when attempting to predict from a Tigger lsm with more than one SPI component. A currently unanswered question is which convention should be used when evaluating the spectral polynomial. 