### PR TITLE
Write out diagonal entries of jhj matrix when solving parameterized terms.

### DIFF
--- a/quartical/calibration/constructor.py
+++ b/quartical/calibration/constructor.py
@@ -165,6 +165,13 @@ def construct_solver(
                     np.int8
                 )
 
+                blocker.add_output(
+                    f"{term_name}-jhj",
+                    ("row", "chan", "ant", "dir", "param"),
+                    term_xds.PARAM_SPEC,
+                    np.float64
+                )
+
             else:  # Only non-parameterised gains return a jhj (for now).
                 blocker.add_output(
                     f"{term_name}-jhj",
@@ -237,6 +244,9 @@ def construct_solver(
                 param_flags = output_dict[f"{term_name}-param_flags"]
                 result_vars["param_flags"] = \
                     (term_xds.PARAM_AXES[:-1], param_flags)
+
+                jhj = output_dict[f"{term_name}-jhj"]
+                result_vars["jhj"] = (term_xds.PARAM_AXES, jhj)
             else:
                 jhj = output_dict[f"{term_name}-jhj"]
                 result_vars["jhj"] = (term_xds.GAIN_AXES, jhj)

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -174,6 +174,7 @@ def delay_solver(base_args, term_args, meta_args, corr_mode):
                              meta_args)
 
         active_params[..., 1::2] /= min_freq  # Undo scaling for SI units.
+        native_imdry.jhj[..., 1::2] *= min_freq ** 2
 
         return native_imdry.jhj, term_conv_info(loop_idx + 1, conv_perc)
 

--- a/quartical/gains/delay/pure_kernel.py
+++ b/quartical/gains/delay/pure_kernel.py
@@ -186,6 +186,7 @@ def pure_delay_solver(base_args, term_args, meta_args, corr_mode):
                              meta_args)
 
         active_params[..., 1::2] /= min_freq  # Undo scaling for SI units.
+        native_imdry.jhj[..., 1::2] *= min_freq ** 2
 
         return native_imdry.jhj, term_conv_info(loop_idx + 1, conv_perc)
 

--- a/quartical/gains/tec/kernel.py
+++ b/quartical/gains/tec/kernel.py
@@ -112,6 +112,7 @@ def tec_solver(base_args, term_args, meta_args, corr_mode):
         scaled_icf = term_args.CHAN_FREQ.copy()  # Don't mutate.
         min_freq = np.min(scaled_icf)
         scaled_icf = min_freq/scaled_icf  # Scale freqs to avoid precision.
+        scaled_icf *= 2*np.pi  # Introduce 2pi here - neglect everywhere else.
         active_params[..., 1::2] /= min_freq  # Scale consistently with freq.
 
         for loop_idx in range(max_iter):
@@ -174,6 +175,7 @@ def tec_solver(base_args, term_args, meta_args, corr_mode):
                              meta_args)
 
         active_params[..., 1::2] *= min_freq  # Undo scaling for SI units.
+        native_imdry.jhj[..., 1::2] /= min_freq ** 2
 
         return native_imdry.jhj, term_conv_info(loop_idx + 1, conv_perc)
 


### PR DESCRIPTION
This functionality had been added and seems to work. One known issue is the scaling of certain values. Due to the scaling of values like the channel frequencies, the entries of jhj will also end up being scaled. I am yet to figure out the correct way of unscaling jhj values.