### PR TITLE
Replace all instances of `generated_jit` with `overload`.

### DIFF
--- a/quartical/calibration/calibrate.py
+++ b/quartical/calibration/calibrate.py
@@ -12,22 +12,6 @@ from quartical.interpolation.interpolate import load_and_interpolate_gains
 from quartical.gains.baseline import (compute_baseline_corrections,
                                       apply_baseline_corrections)
 from loguru import logger  # noqa
-from collections import namedtuple
-
-
-# The following supresses the egregious numba pending deprecation warnings.
-# TODO: Make sure that the code doesn't break when they finally decprecate
-# reflected lists.
-from numba.core.errors import NumbaDeprecationWarning
-from numba.core.errors import NumbaPendingDeprecationWarning
-import warnings
-
-warnings.simplefilter('ignore', category=NumbaDeprecationWarning)
-warnings.simplefilter('ignore', category=NumbaPendingDeprecationWarning)
-
-
-dstat_dims_tup = namedtuple("dstat_dims_tup",
-                            "n_utime n_chan n_ant n_t_chunk n_f_chunk")
 
 
 def dask_residual(

--- a/quartical/flagging/flagging_kernels.py
+++ b/quartical/flagging/flagging_kernels.py
@@ -1,13 +1,14 @@
 import numpy as np
-from numba import jit
+from numba import njit
+from quartical.utils.numba import JIT_OPTIONS
 
 
-@jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
+@njit(**JIT_OPTIONS)
 def get_bl_ids(a1, a2, n_ant):
     return a1*(2*n_ant - a1 - 1)//2 + a2
 
 
-@jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
+@njit(**JIT_OPTIONS)
 def compute_whitened_residual(resid_arr, weights):
 
     n_row, n_chan, n_corr = resid_arr.shape
@@ -26,7 +27,7 @@ def compute_whitened_residual(resid_arr, weights):
     return wres
 
 
-@jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
+@njit(**JIT_OPTIONS)
 def compute_bl_mad_and_med(wres, flags, a1, a2, n_ant):
 
     n_corr = wres.shape[-1]
@@ -61,7 +62,7 @@ def compute_bl_mad_and_med(wres, flags, a1, a2, n_ant):
     return mad_and_med
 
 
-@jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
+@njit(**JIT_OPTIONS)
 def compute_gbl_mad_and_med(wres, flags):
 
     n_corr = wres.shape[-1]
@@ -84,7 +85,7 @@ def compute_gbl_mad_and_med(wres, flags):
     return mad_and_med
 
 
-@jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
+@njit(**JIT_OPTIONS)
 def compute_mad_flags(
     wres,
     gbl_mad_and_med_real,

--- a/quartical/gains/amplitude/kernel.py
+++ b/quartical/gains/amplitude/kernel.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-from numba import prange, generated_jit, jit
-from quartical.utils.numba import coerce_literal
+from numba import prange, njit
+from numba.extending import overload
+from quartical.utils.numba import (coerce_literal,
+                                   JIT_OPTIONS,
+                                   PARALLEL_JIT_OPTIONS)
 from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
@@ -29,13 +32,7 @@ def get_identity_params(corr_mode):
         raise ValueError("Unsupported number of correlations.")
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def amplitude_solver(
     ms_inputs,
     mapping_inputs,
@@ -43,8 +40,35 @@ def amplitude_solver(
     meta_inputs,
     corr_mode
 ):
+    return amplitude_solver_impl(
+        ms_inputs,
+        mapping_inputs,
+        chain_inputs,
+        meta_inputs,
+        corr_mode
+    )
 
-    coerce_literal(amplitude_solver, ["corr_mode"])
+
+def amplitude_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(amplitude_solver_impl, jit_options=JIT_OPTIONS)
+def nb_amplitude_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+
+    coerce_literal(nb_amplitude_solver_impl, ["corr_mode"])
 
     identity_params = get_identity_params(corr_mode)
 
@@ -180,14 +204,20 @@ def amplitude_solver(
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=True,
-    cache=True,
-    nogil=True
-)
 def compute_jhj_jhr(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    upsampled_imdry,
+    extents,
+    corr_mode
+):
+    return NotImplementedError
+
+
+@overload(compute_jhj_jhr, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_jhj_jhr(
     ms_inputs,
     mapping_inputs,
     chain_inputs,
@@ -412,12 +442,12 @@ def compute_jhj_jhr(
     return impl
 
 
-@generated_jit(nopython=True,
-               fastmath=True,
-               parallel=True,
-               cache=True,
-               nogil=True)
 def compute_update(native_imdry, corr_mode):
+    raise NotImplementedError
+
+
+@overload(compute_update, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_update(native_imdry, corr_mode):
 
     # We want to dispatch based on this field so we need its type.
     jhj = native_imdry[native_imdry.fields.index('jhj')]
@@ -456,14 +486,18 @@ def compute_update(native_imdry, corr_mode):
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
 def finalize_update(
+    chain_inputs,
+    meta_inputs,
+    native_imdry,
+    loop_idx,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(finalize_update, jit_options=JIT_OPTIONS)
+def nb_finalize_update(
     chain_inputs,
     meta_inputs,
     native_imdry,
@@ -631,13 +665,7 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
     return factories.qcjit(impl)
 
 
-@jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def amplitude_params_to_gains(
     params,
     gains

--- a/quartical/gains/complex/kernel.py
+++ b/quartical/gains/complex/kernel.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-from numba import prange, generated_jit
-from quartical.utils.numba import coerce_literal
+from numba import prange, njit
+from numba.extending import overload
+from quartical.utils.numba import (coerce_literal,
+                                   JIT_OPTIONS,
+                                   PARALLEL_JIT_OPTIONS)
 from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
@@ -18,13 +21,7 @@ from quartical.gains.general.inversion import (invert_factory,
                                                inversion_buffer_factory)
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def complex_solver(
     ms_inputs,
     mapping_inputs,
@@ -32,8 +29,35 @@ def complex_solver(
     meta_inputs,
     corr_mode
 ):
+    return complex_solver_impl(
+        ms_inputs,
+        mapping_inputs,
+        chain_inputs,
+        meta_inputs,
+        corr_mode
+    )
 
-    coerce_literal(complex_solver, ["corr_mode"])
+
+def complex_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(complex_solver_impl, jit_options=JIT_OPTIONS)
+def nb_complex_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+
+    coerce_literal(nb_complex_solver_impl, ["corr_mode"])
 
     get_jhj_dims = get_jhj_dims_factory(corr_mode)
 
@@ -155,14 +179,20 @@ def complex_solver(
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=True,
-    cache=True,
-    nogil=True
-)
 def compute_jhj_jhr(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    upsampled_imdry,
+    extents,
+    corr_mode
+):
+    return NotImplementedError
+
+
+@overload(compute_jhj_jhr, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_jhj_jhr(
     ms_inputs,
     mapping_inputs,
     chain_inputs,
@@ -387,12 +417,12 @@ def compute_jhj_jhr(
     return impl
 
 
-@generated_jit(nopython=True,
-               fastmath=True,
-               parallel=True,
-               cache=True,
-               nogil=True)
 def compute_update(native_imdry, corr_mode):
+    raise NotImplementedError
+
+
+@overload(compute_update, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_update(native_imdry, corr_mode):
 
     # We want to dispatch based on this field so we need its type.
     jhj = native_imdry[native_imdry.fields.index('jhj')]
@@ -431,14 +461,18 @@ def compute_update(native_imdry, corr_mode):
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
 def finalize_update(
+    chain_inputs,
+    meta_inputs,
+    native_imdry,
+    loop_idx,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(finalize_update, jit_options=JIT_OPTIONS)
+def nb_finalize_update(
     chain_inputs,
     meta_inputs,
     native_imdry,

--- a/quartical/gains/crosshand_phase/kernel.py
+++ b/quartical/gains/crosshand_phase/kernel.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-from numba import prange, generated_jit, jit
-from quartical.utils.numba import coerce_literal
+from numba import prange, njit
+from numba.extending import overload
+from quartical.utils.numba import (coerce_literal,
+                                   JIT_OPTIONS,
+                                   PARALLEL_JIT_OPTIONS)
 from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
@@ -27,13 +30,7 @@ def get_identity_params(corr_mode):
         raise ValueError("Unsupported number of correlations.")
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def crosshand_phase_solver(
     ms_inputs,
     mapping_inputs,
@@ -41,8 +38,35 @@ def crosshand_phase_solver(
     meta_inputs,
     corr_mode
 ):
+    return crosshand_phase_solver_impl(
+        ms_inputs,
+        mapping_inputs,
+        chain_inputs,
+        meta_inputs,
+        corr_mode
+    )
 
-    coerce_literal(crosshand_phase_solver, ["corr_mode"])
+
+def crosshand_phase_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(crosshand_phase_solver_impl, jit_options=JIT_OPTIONS)
+def nb_crosshand_phase_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+
+    coerce_literal(nb_crosshand_phase_solver_impl, ["corr_mode"])
 
     identity_params = get_identity_params(corr_mode)
 
@@ -178,14 +202,20 @@ def crosshand_phase_solver(
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=True,
-    cache=True,
-    nogil=True
-)
 def compute_jhj_jhr(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    upsampled_imdry,
+    extents,
+    corr_mode
+):
+    return NotImplementedError
+
+
+@overload(compute_jhj_jhr, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_jhj_jhr(
     ms_inputs,
     mapping_inputs,
     chain_inputs,
@@ -416,12 +446,12 @@ def compute_jhj_jhr(
     return impl
 
 
-@generated_jit(nopython=True,
-               fastmath=True,
-               parallel=True,
-               cache=True,
-               nogil=True)
 def compute_update(native_imdry, corr_mode):
+    raise NotImplementedError
+
+
+@overload(compute_update, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_update(native_imdry, corr_mode):
 
     # We want to dispatch based on this field so we need its type.
     jhj = native_imdry[native_imdry.fields.index('jhj')]
@@ -460,14 +490,18 @@ def compute_update(native_imdry, corr_mode):
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
 def finalize_update(
+    chain_inputs,
+    meta_inputs,
+    native_imdry,
+    loop_idx,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(finalize_update, jit_options=JIT_OPTIONS)
+def nb_finalize_update(
     chain_inputs,
     meta_inputs,
     native_imdry,
@@ -601,13 +635,7 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
     return factories.qcjit(impl)
 
 
-@jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def crosshand_params_to_gains(
     params,
     gains

--- a/quartical/gains/datasets.py
+++ b/quartical/gains/datasets.py
@@ -112,7 +112,6 @@ def combine_gains_wrapper(
 
 def combine_flags_wrapper(
     net_shape,
-    corr_mode,
     *args
 ):
     """Wrapper to stop dask from getting confused. See issue #99."""
@@ -127,8 +126,7 @@ def combine_flags_wrapper(
         time_bins,
         freq_maps,
         dir_maps,
-        net_shape,
-        corr_mode,
+        net_shape
     )
 
 
@@ -249,7 +247,6 @@ def populate_net_xds_list(
             net_flags = da.blockwise(
                 combine_flags_wrapper, net_xds.GAIN_AXES[:-1],
                 net_shape, None,
-                corr_mode, None,
                 *req_args,
                 dtype=np.int8,
                 align_arrays=False,

--- a/quartical/gains/delay/pure_kernel.py
+++ b/quartical/gains/delay/pure_kernel.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-from numba import generated_jit
-from quartical.utils.numba import coerce_literal
+from numba import njit
+from numba.extending import overload
+from quartical.utils.numba import coerce_literal, JIT_OPTIONS
 from quartical.gains.general.generics import (
     native_intermediaries,
     upsampled_itermediaries,
@@ -36,13 +37,7 @@ def get_identity_params(corr_mode):
         raise ValueError("Unsupported number of correlations.")
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def pure_delay_solver(
     ms_inputs,
     mapping_inputs,
@@ -50,8 +45,35 @@ def pure_delay_solver(
     meta_inputs,
     corr_mode
 ):
+    return pure_delay_solver_impl(
+        ms_inputs,
+        mapping_inputs,
+        chain_inputs,
+        meta_inputs,
+        corr_mode
+    )
 
-    coerce_literal(pure_delay_solver, ["corr_mode"])
+
+def pure_delay_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(pure_delay_solver_impl, jit_options=JIT_OPTIONS)
+def nb_pure_delay_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+
+    coerce_literal(nb_pure_delay_solver_impl, ["corr_mode"])
 
     identity_params = get_identity_params(corr_mode)
 

--- a/quartical/gains/general/convenience.py
+++ b/quartical/gains/general/convenience.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from numba import jit, types, generated_jit
+from numba import njit, types
+from numba.extending import overload
+from quartical.utils.numba import JIT_OPTIONS
 import numpy as np
 from collections import namedtuple
 
@@ -14,24 +16,23 @@ extent_tuple = namedtuple(
     )
 )
 
-# Handy alias for functions that need to be jitted in this way.
-qcjit = jit(nogil=True,
-            nopython=True,
-            fastmath=True,
-            cache=True,
-            inline="always")
-
-qcgjit = generated_jit(nogil=True,
-                       nopython=True,
-                       fastmath=True,
-                       cache=True)
 
 # TODO: Consider whether these should have true optionals. This will likely
-# require them all to be implemented as overloads.
+# require them all to be implemented as overloads. We could also consider
+# moving this code into the factories.
 
 
-@qcgjit
+@njit(**JIT_OPTIONS)
 def get_dims(col, row_map):
+    return get_dims_impl(col, row_map)
+
+
+def get_dims_impl(col, row_map):
+    return NotImplementedError
+
+
+@overload(get_dims_impl, jit_options=JIT_OPTIONS)
+def nb_get_dims_impl(col, row_map):
     """Returns effective column dimensions. This may be larger than col.
 
     Args:
@@ -59,8 +60,17 @@ def get_dims(col, row_map):
     return impl
 
 
-@qcgjit
+@njit(**JIT_OPTIONS)
 def get_row(row_ind, row_map):
+    return get_row_impl(row_ind, row_map)
+
+
+def get_row_impl(row_ind, row_map):
+    return NotImplementedError
+
+
+@overload(get_row_impl, jit_options=JIT_OPTIONS)
+def nb_get_row_impl(row_ind, row_map):
     """Gets the current row index. Row map is needed for the BDA case.
 
     Args:
@@ -80,7 +90,7 @@ def get_row(row_ind, row_map):
     return impl
 
 
-@qcjit
+@njit(**JIT_OPTIONS)
 def get_extents(t_map, f_map):
     """Given the time/freq mappings, determine run start and stop indices."""
 
@@ -90,7 +100,7 @@ def get_extents(t_map, f_map):
     return extent_tuple(row_starts, row_stops, chan_starts, chan_stops)
 
 
-@qcjit
+@njit(**JIT_OPTIONS)
 def get_chan_extents(f_map_arr):
     """Given the frequency mappings, determines the start/stop indices."""
 
@@ -111,7 +121,7 @@ def get_chan_extents(f_map_arr):
     return chan_starts, chan_stops
 
 
-@qcjit
+@njit(**JIT_OPTIONS)
 def get_row_extents(t_map_arr):
     """Given the time mappings, determines the row start/stop indices."""
 

--- a/quartical/gains/general/factories.py
+++ b/quartical/gains/general/factories.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
-from numba import jit, types
 import numpy as np
+from numba import njit, types
+from quartical.utils.numba import JIT_OPTIONS
+
 
 # Handy alias for functions that need to be jitted in this way.
-qcjit = jit(nogil=True,
-            nopython=True,
-            fastmath=True,
-            cache=True,
-            inline="always")
+qcjit = njit(**JIT_OPTIONS, inline="always")
 
 
 def imul_rweight_factory(mode, weight):

--- a/quartical/gains/general/flagging.py
+++ b/quartical/gains/general/flagging.py
@@ -268,7 +268,7 @@ def update_param_flags(
 
 
 @overload(update_param_flags, jit_options=JIT_OPTIONS)
-def update_param_flags(
+def update_param_flags_impl(
     mapping_inputs,
     chain_inputs,
     meta_inputs,

--- a/quartical/gains/general/flagging.py
+++ b/quartical/gains/general/flagging.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-from numba import jit, generated_jit
+from numba import njit
+from numba.extending import overload
+from quartical.utils.numba import coerce_literal, JIT_OPTIONS
 from collections import namedtuple
 from quartical.gains.general.convenience import get_row
 import quartical.gains.general.factories as factories
-from quartical.utils.numba import coerce_literal
 
 
 flag_intermediaries = namedtuple(
@@ -18,7 +19,7 @@ flag_intermediaries = namedtuple(
 )
 
 
-@jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
+@njit(**JIT_OPTIONS)
 def init_flags(
     term_shape,
     time_map,
@@ -54,14 +55,19 @@ def init_flags(
     return flags
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
 def update_gain_flags(
+    chain_inputs,
+    meta_inputs,
+    flag_imdry,
+    loop_idx,
+    corr_mode,
+    numbness=1e-6
+):
+    raise NotImplementedError
+
+
+@overload(update_gain_flags, jit_options=JIT_OPTIONS)
+def nb_update_gain_flags(
     chain_inputs,
     meta_inputs,
     flag_imdry,
@@ -89,7 +95,7 @@ def update_gain_flags(
         iteration: An int containing the iteration number.
     """
 
-    coerce_literal(update_gain_flags, ['corr_mode'])
+    coerce_literal(nb_update_gain_flags, ['corr_mode'])
 
     set_identity = factories.set_identity_factory(corr_mode)
 
@@ -203,14 +209,12 @@ def update_gain_flags(
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
 def finalize_gain_flags(chain_inputs, meta_inputs, flag_imdry, corr_mode):
+    return NotImplementedError
+
+
+@overload(finalize_gain_flags, jit_options=JIT_OPTIONS)
+def nb_finalize_gain_flags(chain_inputs, meta_inputs, flag_imdry, corr_mode):
     """Removes soft flags and flags points which failed to converge.
 
     Given the gains, assosciated gain flags and the trend of abosolute
@@ -225,6 +229,8 @@ def finalize_gain_flags(chain_inputs, meta_inputs, flag_imdry, corr_mode):
             the absolute difference between gains at each iteration. Positive
             values correspond to points which are nowhere near convergence.
     """
+
+    coerce_literal(nb_finalize_gain_flags, ['corr_mode'])
 
     set_identity = factories.set_identity_factory(corr_mode)
 
@@ -252,13 +258,16 @@ def finalize_gain_flags(chain_inputs, meta_inputs, flag_imdry, corr_mode):
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+def update_param_flags(
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    identity_params
+):
+    return NotImplementedError
+
+
+@overload(update_param_flags, jit_options=JIT_OPTIONS)
 def update_param_flags(
     mapping_inputs,
     chain_inputs,
@@ -325,7 +334,7 @@ def update_param_flags(
     return impl
 
 
-@jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
+@njit(**JIT_OPTIONS)
 def apply_gain_flags(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
     """Apply gain_flags to flag_col."""
 

--- a/quartical/gains/general/generics.py
+++ b/quartical/gains/general/generics.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-from numba import prange, generated_jit, jit
+from numba import prange, njit
 from numba.typed import List
 from collections import namedtuple
-from quartical.utils.numba import coerce_literal
+from numba.extending import overload
+from quartical.utils.numba import JIT_OPTIONS, coerce_literal
 import quartical.gains.general.factories as factories
 from quartical.gains.general.convenience import get_dims, get_row
 
@@ -45,23 +46,19 @@ resample_outputs = namedtuple(
 )
 
 
-qcgjit = generated_jit(nopython=True,
-                       fastmath=True,
-                       parallel=False,
-                       cache=True,
-                       nogil=True)
-
-qcgjit_parallel = generated_jit(nopython=True,
-                                fastmath=True,
-                                parallel=True,
-                                cache=True,
-                                nogil=True)
-
-
-@qcgjit
+@njit(**JIT_OPTIONS)
 def invert_gains(gain_list, inverse_gains, corr_mode):
+    return invert_gains_impl(gain_list, inverse_gains, corr_mode)
 
-    coerce_literal(invert_gains, ["corr_mode"])
+
+def invert_gains_impl(gain_list, inverse_gains, corr_mode):
+    raise NotImplementedError
+
+
+@overload(invert_gains_impl, jit_options=JIT_OPTIONS)
+def nb_invert_gains_impl(gain_list, inverse_gains, corr_mode):
+
+    coerce_literal(nb_invert_gains_impl, ["corr_mode"])
 
     compute_det = factories.compute_det_factory(corr_mode)
     iinverse = factories.iinverse_factory(corr_mode)
@@ -91,7 +88,7 @@ def invert_gains(gain_list, inverse_gains, corr_mode):
     return impl
 
 
-@qcgjit
+@njit(**JIT_OPTIONS)
 def compute_residual(
     data,
     model,
@@ -106,8 +103,56 @@ def compute_residual(
     corr_mode,
     sub_dirs=None
 ):
+    return compute_residual_impl(
+        data,
+        model,
+        gain_tuple,
+        a1,
+        a2,
+        time_maps,
+        freq_maps,
+        dir_maps,
+        row_map,
+        row_weights,
+        corr_mode,
+        sub_dirs
+    )
 
-    coerce_literal(compute_residual, ["corr_mode"])
+
+def compute_residual_impl(
+    data,
+    model,
+    gain_tuple,
+    a1,
+    a2,
+    time_maps,
+    freq_maps,
+    dir_maps,
+    row_map,
+    row_weights,
+    corr_mode,
+    sub_dirs=None
+):
+    raise NotImplementedError
+
+
+@overload(compute_residual_impl, jit_options=JIT_OPTIONS)
+def nb_compute_residual_impl(
+    data,
+    model,
+    gain_tuple,
+    a1,
+    a2,
+    time_maps,
+    freq_maps,
+    dir_maps,
+    row_map,
+    row_weights,
+    corr_mode,
+    sub_dirs=None
+):
+
+    coerce_literal(nb_compute_residual_impl, ["corr_mode"])
 
     imul_rweight = factories.imul_rweight_factory(corr_mode, row_weights)
     v1_imul_v2 = factories.v1_imul_v2_factory(corr_mode)
@@ -177,7 +222,7 @@ def compute_residual(
     return impl
 
 
-@qcgjit
+@njit(**JIT_OPTIONS)
 def compute_corrected_residual(
     residual,
     gain_tuple,
@@ -190,8 +235,50 @@ def compute_corrected_residual(
     row_weights,
     corr_mode
 ):
+    return compute_corrected_residual_impl(
+        residual,
+        gain_tuple,
+        a1,
+        a2,
+        time_maps,
+        freq_maps,
+        dir_maps,
+        row_map,
+        row_weights,
+        corr_mode
+    )
 
-    coerce_literal(compute_corrected_residual, ["corr_mode"])
+
+def compute_corrected_residual_impl(
+    residual,
+    gain_tuple,
+    a1,
+    a2,
+    time_maps,
+    freq_maps,
+    dir_maps,
+    row_map,
+    row_weights,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(compute_corrected_residual_impl, jit_options=JIT_OPTIONS)
+def nb_compute_corrected_residual_impl(
+    residual,
+    gain_tuple,
+    a1,
+    a2,
+    time_maps,
+    freq_maps,
+    dir_maps,
+    row_map,
+    row_weights,
+    corr_mode
+):
+
+    coerce_literal(nb_compute_corrected_residual_impl, ["corr_mode"])
 
     imul_rweight = factories.imul_rweight_factory(corr_mode, row_weights)
     v1_imul_v2 = factories.v1_imul_v2_factory(corr_mode)
@@ -257,7 +344,7 @@ def compute_corrected_residual(
     return impl
 
 
-@qcgjit
+@njit(**JIT_OPTIONS)
 def compute_corrected_weights(
     weights,
     gain_tuple,
@@ -270,8 +357,50 @@ def compute_corrected_weights(
     row_weights,
     corr_mode
 ):
+    return compute_corrected_weights_impl(
+        weights,
+        gain_tuple,
+        a1,
+        a2,
+        time_maps,
+        freq_maps,
+        dir_maps,
+        row_map,
+        row_weights,
+        corr_mode
+    )
 
-    coerce_literal(compute_corrected_weights, ["corr_mode"])
+
+def compute_corrected_weights_impl(
+    weights,
+    gain_tuple,
+    a1,
+    a2,
+    time_maps,
+    freq_maps,
+    dir_maps,
+    row_map,
+    row_weights,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(compute_corrected_weights_impl, jit_options=JIT_OPTIONS)
+def nb_compute_corrected_weights_impl(
+    weights,
+    gain_tuple,
+    a1,
+    a2,
+    time_maps,
+    freq_maps,
+    dir_maps,
+    row_map,
+    row_weights,
+    corr_mode
+):
+
+    coerce_literal(nb_compute_corrected_weights_impl, ["corr_mode"])
 
     imul_rweight = factories.imul_rweight_factory(corr_mode, row_weights)
     v1_imul_v2 = factories.v1_imul_v2_factory(corr_mode)
@@ -405,7 +534,7 @@ def corrected_weights_buffer_factory(corr_mode):
     return factories.qcjit(impl)
 
 
-@jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
+@njit(**JIT_OPTIONS)
 def compute_convergence(gain, last_gain, criteria):
 
     n_tint, n_fint, n_ant, n_dir, n_corr = gain.shape
@@ -438,7 +567,7 @@ def compute_convergence(gain, last_gain, criteria):
     return n_cnvgd/(n_tint*n_fint*n_ant*n_dir)
 
 
-@qcgjit
+@njit(**JIT_OPTIONS)
 def combine_gains(
     gains,
     time_bins,
@@ -447,8 +576,38 @@ def combine_gains(
     net_shape,
     corr_mode
 ):
+    return combine_gains_impl(
+        gains,
+        time_bins,
+        freq_maps,
+        dir_maps,
+        net_shape,
+        corr_mode
+    )
 
-    coerce_literal(combine_gains, ["corr_mode"])
+
+def combine_gains_impl(
+    gains,
+    time_bins,
+    freq_maps,
+    dir_maps,
+    net_shape,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(combine_gains_impl, jit_options=JIT_OPTIONS)
+def nb_combine_gains_impl(
+    gains,
+    time_bins,
+    freq_maps,
+    dir_maps,
+    net_shape,
+    corr_mode
+):
+
+    coerce_literal(nb_combine_gains_impl, ["corr_mode"])
 
     v1_imul_v2 = factories.v1_imul_v2_factory(corr_mode)
 
@@ -493,159 +652,134 @@ def combine_gains(
     return impl
 
 
-@qcgjit
+@njit(**JIT_OPTIONS)
 def combine_flags(
     flags,
     time_bins,
     freq_maps,
     dir_maps,
-    net_shape,
-    corr_mode
+    net_shape
 ):
 
-    def impl(
-        flags,
-        time_bins,
-        freq_maps,
-        dir_maps,
-        net_shape,
-        corr_mode
-    ):
+    n_term = len(flags)
+    n_time = time_bins[0].size  # Same for all terms.
+    n_freq = freq_maps[0].size  # Same for all terms.
+    _, _, n_ant, n_dir, _ = net_shape
 
-        n_term = len(flags)
-        n_time = time_bins[0].size  # Same for all terms.
-        n_freq = freq_maps[0].size  # Same for all terms.
-        _, _, n_ant, n_dir, _ = net_shape
+    shape = (n_time, n_freq, n_ant, n_dir)
 
-        shape = (n_time, n_freq, n_ant, n_dir)
+    net_flags = np.zeros(shape, dtype=np.int8)
 
-        net_flags = np.zeros(shape, dtype=np.int8)
+    for t in range(n_time):
+        for f in range(n_freq):
+            for a in range(n_ant):
+                for d in range(n_dir):
+                    for gi in range(n_term):
 
-        for t in range(n_time):
-            for f in range(n_freq):
-                for a in range(n_ant):
-                    for d in range(n_dir):
-                        for gi in range(n_term):
+                        tm = time_bins[gi][t]
+                        fm = freq_maps[gi][f]
+                        dm = dir_maps[gi][d]
 
-                            tm = time_bins[gi][t]
-                            fm = freq_maps[gi][f]
-                            dm = dir_maps[gi][d]
+                        net_flags[t, f, a, d] |= flags[gi][tm, fm, a, dm]
 
-                            net_flags[t, f, a, d] |= flags[gi][tm, fm, a, dm]
-
-        return net_flags
-
-    return impl
+    return net_flags
 
 
-@generated_jit(nopython=True, fastmath=True, parallel=False, cache=True,
-               nogil=True)
+@njit(**JIT_OPTIONS)
 def per_array_jhj_jhr(solver_imdry):
     """This manipulates the entries of jhj and jhr to be over all antennas."""
 
-    def impl(solver_imdry):
+    jhj = solver_imdry.jhj
+    jhr = solver_imdry.jhr
 
-        jhj = solver_imdry.jhj
-        jhr = solver_imdry.jhr
+    n_tint, n_fint, n_ant = jhj.shape[:3]
 
-        n_tint, n_fint, n_ant = jhj.shape[:3]
+    for t in range(n_tint):
+        for f in range(n_fint):
+            for a in range(1, n_ant):
+                jhj[t, f, 0] += jhj[t, f, a]
+                jhr[t, f, 0] += jhr[t, f, a]
 
-        for t in range(n_tint):
-            for f in range(n_fint):
-                for a in range(1, n_ant):
-                    jhj[t, f, 0] += jhj[t, f, a]
-                    jhr[t, f, 0] += jhr[t, f, a]
-
-                for a in range(1, n_ant):
-                    jhj[t, f, a] = jhj[t, f, 0]
-                    jhr[t, f, a] = jhr[t, f, 0]
-
-    return impl
+            for a in range(1, n_ant):
+                jhj[t, f, a] = jhj[t, f, 0]
+                jhr[t, f, a] = jhr[t, f, 0]
 
 
-@qcgjit
+@njit(**JIT_OPTIONS)
 def resample_solints(native_map, native_shape, n_thread):
 
-    def impl(native_map, native_shape, n_thread):
+    n_tint, n_fint = native_shape[:2]
+    n_int = n_tint * n_fint
 
-        n_tint, n_fint = native_shape[:2]
-        n_int = n_tint * n_fint
+    if n_int < n_thread:  # TODO: Maybe put some integer factor here?
 
-        if n_int < n_thread:  # TODO: Maybe put some integer factor here?
+        active = True
 
-            active = True
+        remap_factor = np.ceil(n_thread/n_int)
 
-            remap_factor = np.ceil(n_thread/n_int)
+        target_n_tint = int(n_tint * remap_factor)
 
-            target_n_tint = int(n_tint * remap_factor)
+        upsample_map = np.empty_like(native_map)
+        downsample_map = np.empty(target_n_tint, dtype=np.int32)
+        remap_id = 0
+        offset = 0
 
-            upsample_map = np.empty_like(native_map)
-            downsample_map = np.empty(target_n_tint, dtype=np.int32)
-            remap_id = 0
-            offset = 0
+        for i in range(n_tint):
 
-            for i in range(n_tint):
+            sel = np.where(native_map == i)
 
-                sel = np.where(native_map == i)
+            sel_n_row = sel[0].size
 
-                sel_n_row = sel[0].size
+            upsample_n_row = int(np.ceil(sel_n_row/remap_factor))
 
-                upsample_n_row = int(np.ceil(sel_n_row/remap_factor))
+            for start in range(offset, offset + sel_n_row, upsample_n_row):
 
-                for start in range(offset, offset + sel_n_row, upsample_n_row):
+                stop = min(start + upsample_n_row, offset + sel_n_row)
 
-                    stop = min(start + upsample_n_row, offset + sel_n_row)
+                upsample_map[start:stop] = remap_id
+                downsample_map[remap_id] = i
 
-                    upsample_map[start:stop] = remap_id
-                    downsample_map[remap_id] = i
+                remap_id += 1
 
-                    remap_id += 1
+            offset += sel_n_row
 
-                offset += sel_n_row
+        upsample_shape = (target_n_tint,) + native_shape[1:]
 
-            upsample_shape = (target_n_tint,) + native_shape[1:]
+    else:
 
-        else:
+        active = False
+        upsample_map = native_map
+        downsample_map = np.empty(0, dtype=np.int32)
+        upsample_shape = native_shape
 
-            active = False
-            upsample_map = native_map
-            downsample_map = np.empty(0, dtype=np.int32)
-            upsample_shape = native_shape
-
-        return resample_outputs(
-            active, upsample_shape, upsample_map, downsample_map
-        )
-
-    return impl
+    return resample_outputs(
+        active, upsample_shape, upsample_map, downsample_map
+    )
 
 
-@qcgjit
+@njit(**JIT_OPTIONS)
 def downsample_jhj_jhr(upsampled_imdry, downsample_t_map):
 
-    def impl(upsampled_imdry, downsample_t_map):
+    jhj = upsampled_imdry.jhj
+    jhr = upsampled_imdry.jhr
 
-        jhj = upsampled_imdry.jhj
-        jhr = upsampled_imdry.jhr
+    n_tint, n_fint, n_ant, n_dir = jhj.shape[:4]
 
-        n_tint, n_fint, n_ant, n_dir = jhj.shape[:4]
+    prev_out_ti = -1
 
-        prev_out_ti = -1
+    for ti in range(n_tint):
 
-        for ti in range(n_tint):
+        out_ti = downsample_t_map[ti]
 
-            out_ti = downsample_t_map[ti]
+        for fi in range(n_fint):
+            for a in range(n_ant):
+                for d in range(n_dir):
 
-            for fi in range(n_fint):
-                for a in range(n_ant):
-                    for d in range(n_dir):
+                    if prev_out_ti != out_ti:
+                        jhj[out_ti, fi, a, d] = jhj[ti, fi, a, d]
+                        jhr[out_ti, fi, a, d] = jhr[ti, fi, a, d]
+                    else:
+                        jhj[out_ti, fi, a, d] += jhj[ti, fi, a, d]
+                        jhr[out_ti, fi, a, d] += jhr[ti, fi, a, d]
 
-                        if prev_out_ti != out_ti:
-                            jhj[out_ti, fi, a, d] = jhj[ti, fi, a, d]
-                            jhr[out_ti, fi, a, d] = jhr[ti, fi, a, d]
-                        else:
-                            jhj[out_ti, fi, a, d] += jhj[ti, fi, a, d]
-                            jhr[out_ti, fi, a, d] += jhr[ti, fi, a, d]
-
-            prev_out_ti = out_ti
-
-    return impl
+        prev_out_ti = out_ti

--- a/quartical/gains/leakage/kernel.py
+++ b/quartical/gains/leakage/kernel.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-from numba import generated_jit
-from quartical.utils.numba import coerce_literal
+from numba import njit
+from numba.extending import overload
+from quartical.utils.numba import coerce_literal, JIT_OPTIONS
 from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
@@ -18,13 +19,7 @@ from quartical.gains.complex.kernel import (get_jhj_dims_factory,
                                             compute_update)
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def leakage_solver(
     ms_inputs,
     mapping_inputs,
@@ -32,8 +27,35 @@ def leakage_solver(
     meta_inputs,
     corr_mode
 ):
+    return leakage_solver_impl(
+        ms_inputs,
+        mapping_inputs,
+        chain_inputs,
+        meta_inputs,
+        corr_mode
+    )
 
-    coerce_literal(leakage_solver, ["corr_mode"])
+
+def leakage_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(leakage_solver_impl, jit_options=JIT_OPTIONS)
+def nb_leakage_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+
+    coerce_literal(nb_leakage_solver_impl, ["corr_mode"])
 
     get_jhj_dims = get_jhj_dims_factory(corr_mode)
 
@@ -159,14 +181,18 @@ def leakage_solver(
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
 def finalize_update(
+    chain_inputs,
+    meta_inputs,
+    native_imdry,
+    loop_idx,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(finalize_update, jit_options=JIT_OPTIONS)
+def nb_finalize_update(
     chain_inputs,
     meta_inputs,
     native_imdry,

--- a/quartical/gains/phase/kernel.py
+++ b/quartical/gains/phase/kernel.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-from numba import prange, generated_jit, jit
-from quartical.utils.numba import coerce_literal
+from numba import prange, njit
+from numba.extending import overload
+from quartical.utils.numba import (coerce_literal,
+                                   JIT_OPTIONS,
+                                   PARALLEL_JIT_OPTIONS)
 from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
@@ -29,13 +32,7 @@ def get_identity_params(corr_mode):
         raise ValueError("Unsupported number of correlations.")
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def phase_solver(
     ms_inputs,
     mapping_inputs,
@@ -43,8 +40,35 @@ def phase_solver(
     meta_inputs,
     corr_mode
 ):
+    return phase_solver_impl(
+        ms_inputs,
+        mapping_inputs,
+        chain_inputs,
+        meta_inputs,
+        corr_mode
+    )
 
-    coerce_literal(phase_solver, ["corr_mode"])
+
+def phase_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(phase_solver_impl, jit_options=JIT_OPTIONS)
+def nb_phase_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+
+    coerce_literal(nb_phase_solver_impl, ["corr_mode"])
 
     identity_params = get_identity_params(corr_mode)
 
@@ -181,14 +205,20 @@ def phase_solver(
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=True,
-    cache=True,
-    nogil=True
-)
 def compute_jhj_jhr(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    upsampled_imdry,
+    extents,
+    corr_mode
+):
+    return NotImplementedError
+
+
+@overload(compute_jhj_jhr, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_jhj_jhr(
     ms_inputs,
     mapping_inputs,
     chain_inputs,
@@ -419,12 +449,12 @@ def compute_jhj_jhr(
     return impl
 
 
-@generated_jit(nopython=True,
-               fastmath=True,
-               parallel=True,
-               cache=True,
-               nogil=True)
 def compute_update(native_imdry, corr_mode):
+    raise NotImplementedError
+
+
+@overload(compute_update, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_update(native_imdry, corr_mode):
 
     # We want to dispatch based on this field so we need its type.
     jhj = native_imdry[native_imdry.fields.index('jhj')]
@@ -463,14 +493,18 @@ def compute_update(native_imdry, corr_mode):
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
 def finalize_update(
+    chain_inputs,
+    meta_inputs,
+    native_imdry,
+    loop_idx,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(finalize_update, jit_options=JIT_OPTIONS)
+def nb_finalize_update(
     chain_inputs,
     meta_inputs,
     native_imdry,
@@ -684,13 +718,7 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
     return factories.qcjit(impl)
 
 
-@jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def phase_params_to_gains(
     params,
     gains

--- a/quartical/gains/rotation/kernel.py
+++ b/quartical/gains/rotation/kernel.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-from numba import prange, generated_jit, jit
-from quartical.utils.numba import coerce_literal
+from numba import prange, njit
+from numba.extending import overload
+from quartical.utils.numba import (coerce_literal,
+                                   JIT_OPTIONS,
+                                   PARALLEL_JIT_OPTIONS)
 from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
@@ -27,13 +30,7 @@ def get_identity_params(corr_mode):
         raise ValueError("Unsupported number of correlations.")
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def rotation_solver(
     ms_inputs,
     mapping_inputs,
@@ -41,8 +38,35 @@ def rotation_solver(
     meta_inputs,
     corr_mode
 ):
+    return rotation_solver_impl(
+        ms_inputs,
+        mapping_inputs,
+        chain_inputs,
+        meta_inputs,
+        corr_mode
+    )
 
-    coerce_literal(rotation_solver, ["corr_mode"])
+
+def rotation_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(rotation_solver_impl, jit_options=JIT_OPTIONS)
+def nb_rotation_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+
+    coerce_literal(nb_rotation_solver_impl, ["corr_mode"])
 
     identity_params = get_identity_params(corr_mode)
 
@@ -181,14 +205,20 @@ def rotation_solver(
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=True,
-    cache=True,
-    nogil=True
-)
 def compute_jhj_jhr(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    upsampled_imdry,
+    extents,
+    corr_mode
+):
+    return NotImplementedError
+
+
+@overload(compute_jhj_jhr, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_jhj_jhr(
     ms_inputs,
     mapping_inputs,
     chain_inputs,
@@ -426,12 +456,12 @@ def compute_jhj_jhr(
     return impl
 
 
-@generated_jit(nopython=True,
-               fastmath=True,
-               parallel=True,
-               cache=True,
-               nogil=True)
 def compute_update(native_imdry, corr_mode):
+    raise NotImplementedError
+
+
+@overload(compute_update, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_update(native_imdry, corr_mode):
 
     # We want to dispatch based on this field so we need its type.
     jhj = native_imdry[native_imdry.fields.index('jhj')]
@@ -470,14 +500,19 @@ def compute_update(native_imdry, corr_mode):
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
 def finalize_update(
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    native_imdry,
+    loop_idx,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(finalize_update, jit_options=JIT_OPTIONS)
+def nb_finalize_update(
     mapping_inputs,
     chain_inputs,
     meta_inputs,
@@ -615,13 +650,7 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
     return factories.qcjit(impl)
 
 
-@jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def rotation_params_to_gains(
     params,
     gains

--- a/quartical/gains/rotation_measure/kernel.py
+++ b/quartical/gains/rotation_measure/kernel.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-from numba import prange, generated_jit, jit
-from quartical.utils.numba import coerce_literal
+from numba import prange, njit
+from numba.extending import overload
+from quartical.utils.numba import (coerce_literal,
+                                   JIT_OPTIONS,
+                                   PARALLEL_JIT_OPTIONS)
 from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
@@ -27,13 +30,7 @@ def get_identity_params(corr_mode):
         raise ValueError("Unsupported number of correlations.")
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def rm_solver(
     ms_inputs,
     mapping_inputs,
@@ -41,8 +38,35 @@ def rm_solver(
     meta_inputs,
     corr_mode
 ):
+    return rm_solver_impl(
+        ms_inputs,
+        mapping_inputs,
+        chain_inputs,
+        meta_inputs,
+        corr_mode
+    )
 
-    coerce_literal(rm_solver, ["corr_mode"])
+
+def rm_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(rm_solver_impl, jit_options=JIT_OPTIONS)
+def nb_rm_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+
+    coerce_literal(nb_rm_solver_impl, ["corr_mode"])
 
     identity_params = get_identity_params(corr_mode)
 
@@ -185,14 +209,21 @@ def rm_solver(
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=True,
-    cache=True,
-    nogil=True
-)
 def compute_jhj_jhr(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    upsampled_imdry,
+    extents,
+    lambda_sq,
+    corr_mode
+):
+    return NotImplementedError
+
+
+@overload(compute_jhj_jhr, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_jhj_jhr(
     ms_inputs,
     mapping_inputs,
     chain_inputs,
@@ -436,12 +467,12 @@ def compute_jhj_jhr(
     return impl
 
 
-@generated_jit(nopython=True,
-               fastmath=True,
-               parallel=True,
-               cache=True,
-               nogil=True)
 def compute_update(native_imdry, corr_mode):
+    raise NotImplementedError
+
+
+@overload(compute_update, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_update(native_imdry, corr_mode):
 
     # We want to dispatch based on this field so we need its type.
     jhj = native_imdry[native_imdry.fields.index('jhj')]
@@ -480,14 +511,20 @@ def compute_update(native_imdry, corr_mode):
     return impl
 
 
-@generated_jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
 def finalize_update(
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    native_imdry,
+    loop_idx,
+    lambda_sq,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(finalize_update, jit_options=JIT_OPTIONS)
+def nb_finalize_update(
     mapping_inputs,
     chain_inputs,
     meta_inputs,
@@ -634,13 +671,7 @@ def compute_jhwj_jhwr_elem_factory(corr_mode):
     return factories.qcjit(impl)
 
 
-@jit(
-    nopython=True,
-    fastmath=True,
-    parallel=False,
-    cache=True,
-    nogil=True
-)
+@njit(**JIT_OPTIONS)
 def rm_params_to_gains(
     params,
     gains,

--- a/quartical/interpolation/interpolants.py
+++ b/quartical/interpolation/interpolants.py
@@ -3,7 +3,8 @@ from loguru import logger  # noqa
 import dask.array as da
 import numpy as np
 from scipy.interpolate import interp2d
-from numba import jit
+from numba import njit
+from quartical.utils.numba import JIT_OPTIONS
 
 
 def linear2d_interpolate_gains(source_xds, target_xds):
@@ -124,7 +125,7 @@ def spline2d_interpolate_gains(source_xds, target_xds):
     return output_xds
 
 
-@jit(nopython=True, nogil=True, cache=True)
+@njit(**JIT_OPTIONS)
 def map_ax_itp_to_ax(ax, ax_itp):
     """Given ax_itp, compute indices of closest left-hand points in ax."""
 
@@ -148,7 +149,7 @@ def map_ax_itp_to_ax(ax, ax_itp):
     return out
 
 
-@jit(nopython=True, nogil=True, cache=True)
+@njit(**JIT_OPTIONS)
 def bilinear_interp(x, y, f, x_itp, y_itp):
 
     f_itp = np.zeros((x_itp.size, y_itp.size), dtype=f.dtype)
@@ -187,7 +188,7 @@ def bilinear_interp(x, y, f, x_itp, y_itp):
     return f_itp
 
 
-@jit(nopython=True, nogil=True, cache=True)
+@njit(**{**JIT_OPTIONS, "fastmath": False})  # No fastmath due to nans.
 def _interpolate_missing(x1, x2, y):
     """Interpolate/extend data y along x1 and x2 to fill in missing values."""
 
@@ -228,7 +229,7 @@ def _interpolate_missing(x1, x2, y):
     return yy
 
 
-@jit(nopython=True, nogil=True, cache=True)
+@njit(**JIT_OPTIONS)
 def linterp(x_itp, x_data, y_data):
     """Basic linear interpolation. Extrapolates with closest good value.
 
@@ -274,7 +275,7 @@ def linterp(x_itp, x_data, y_data):
     return y_itp
 
 
-@jit(nopython=True, nogil=True, cache=True)
+@njit(**{**JIT_OPTIONS, "fastmath": False})  # No fastmath due to nans.
 def _interpolate_missing_phase(x1, x2, y):
     """Interpolate/extend data y along x1 and x2 to fill in missing values."""
 
@@ -315,7 +316,7 @@ def _interpolate_missing_phase(x1, x2, y):
     return yy
 
 
-@jit(nopython=True, nogil=True, cache=True)
+@njit(**JIT_OPTIONS)
 def phase_interp(x_itp, x_data, y_data):
     """Basic phase interpolation. Extrapolates with closest good value.
 

--- a/quartical/statistics/stat_kernels.py
+++ b/quartical/statistics/stat_kernels.py
@@ -1,47 +1,116 @@
 import numpy as np
-from numba import prange
-from quartical.utils.numba import coerce_literal
-from quartical.gains.general.generics import qcgjit_parallel
+from numba import njit, prange
+from numba.extending import overload
+from quartical.utils.numba import (coerce_literal,
+                                   JIT_OPTIONS,
+                                   PARALLEL_JIT_OPTIONS)
 from quartical.gains.general.convenience import get_dims, get_row
 import quartical.gains.general.factories as factories
 
 
-@qcgjit_parallel
+@njit(**JIT_OPTIONS)
 def compute_mean_presolve_chisq(
     data,
     model,
     weights,
-    flags
+    flags,
+    row_map,
+    row_weights,
+    corr_mode
+):
+    return compute_mean_presolve_chisq_impl(
+        data,
+        model,
+        weights,
+        flags,
+        row_map,
+        row_weights,
+        corr_mode
+    )
+
+
+def compute_mean_presolve_chisq_impl(
+    data,
+    model,
+    weights,
+    flags,
+    row_map,
+    row_weights,
+    corr_mode
+):
+    return NotImplementedError
+
+
+@overload(compute_mean_presolve_chisq_impl, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_mean_presolve_chisq_impl(
+    data,
+    model,
+    weights,
+    flags,
+    row_map,
+    row_weights,
+    corr_mode
 ):
 
-    n_rows, n_chan, n_dir, n_corr = model.shape
+    coerce_literal(nb_compute_mean_presolve_chisq_impl, ["corr_mode"])
 
-    chisq = 0
-    counts = 0
+    imul_rweight = factories.imul_rweight_factory(corr_mode, row_weights)
+    isub = factories.isub_factory(corr_mode)
+    iunpack = factories.iunpack_factory(corr_mode)
+    valloc = factories.valloc_factory(corr_mode)
 
-    for row in prange(n_rows):
-        tmp = np.empty((n_corr,), dtype=np.complex128)
-        for chan in range(n_chan):
-            tmp[:] = data[row, chan]
-            for dir in range(n_dir):
-                for corr in range(n_corr):
-                    tmp[corr] -= model[row, chan, dir, corr]
-            for corr in range(n_corr):
-                if flags[row, chan] != 1:
-                    w = weights[row, chan, corr]
-                    r = tmp[corr]
-                    chisq += (r.conjugate() * w * r).real
+    def impl(
+        data,
+        model,
+        weights,
+        flags,
+        row_map,
+        row_weights,
+        corr_mode
+    ):
+
+        n_rows, n_chan, n_dir, n_corr = get_dims(model, row_map)
+
+        chisq = 0
+        counts = 0
+
+        for row_ind in prange(n_rows):
+
+            row = get_row(row_ind, row_map)
+            r = valloc(np.complex128)  # Hold data.
+            v = valloc(np.complex128)  # Hold GMGH.
+
+            for f in range(n_chan):
+
+                if flags[row, f]:
+                    continue
+
+                iunpack(r, data[row, f])
+                imul_rweight(r, r, row_weights, row_ind)
+                m = model[row, f]
+                w = weights[row, f]
+
+                for d in range(n_dir):
+
+                    iunpack(v, m[d])
+                    imul_rweight(v, v, row_weights, row_ind)
+                    isub(r, v)
+
+                for c in range(n_corr):
+                    chisq += (r[c].conjugate() * w[c] * r[c]).real
                     counts += 1
 
-    if counts:
-        chisq /= counts
-    else:
-        chisq = np.nan
+        if counts:
+            chisq /= counts
+        else:
+            chisq = np.nan
 
-    return np.array([[chisq]], dtype=np.float64)
+        return np.array([[chisq]], dtype=np.float64)
+
+    return impl
 
 
-@qcgjit_parallel
+@njit(**JIT_OPTIONS)
 def compute_mean_postsolve_chisq(
     data,
     model,
@@ -57,8 +126,59 @@ def compute_mean_postsolve_chisq(
     dir_maps,
     corr_mode
 ):
+    return compute_mean_postsolve_chisq_impl(
+        data,
+        model,
+        weights,
+        flags,
+        a1,
+        a2,
+        row_map,
+        row_weights,
+        gains,
+        time_maps,
+        freq_maps,
+        dir_maps,
+        corr_mode
+    )
 
-    coerce_literal(compute_mean_postsolve_chisq, ["corr_mode"])
+
+def compute_mean_postsolve_chisq_impl(
+    data,
+    model,
+    weights,
+    flags,
+    a1,
+    a2,
+    row_map,
+    row_weights,
+    gains,
+    time_maps,
+    freq_maps,
+    dir_maps,
+    corr_mode
+):
+    return NotImplementedError
+
+
+@overload(compute_mean_postsolve_chisq_impl, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_mean_postsolve_chisq_impl(
+    data,
+    model,
+    weights,
+    flags,
+    a1,
+    a2,
+    row_map,
+    row_weights,
+    gains,
+    time_maps,
+    freq_maps,
+    dir_maps,
+    corr_mode
+):
+
+    coerce_literal(nb_compute_mean_postsolve_chisq_impl, ["corr_mode"])
 
     imul_rweight = factories.imul_rweight_factory(corr_mode, row_weights)
     v1_imul_v2 = factories.v1_imul_v2_factory(corr_mode)

--- a/quartical/utils/intervals.py
+++ b/quartical/utils/intervals.py
@@ -1,6 +1,7 @@
 import numpy as np
-from numba import jit, types
+from numba import njit, types
 from numba.extending import overload
+from quartical.utils.numba import JIT_OPTIONS
 
 
 model_schema = ("rowlike", "chan", "ant", "dir", "corr")
@@ -8,7 +9,9 @@ data_schema = ("rowlike", "chan", "ant", "corr")
 gain_schema = ("rowlike", "chan", "ant", "dir", "corr")
 
 
-# @jit(nopython=True, fastmath=False, parallel=False, cache=True, nogil=True)
+# NOTE: None of this code is in use any more and can likely be deleted.
+
+# @njit(**JIT_OPTIONS)
 # def column_to_tifiac(in_col, t_map, f_map, ant1_col, ant2_col, n_ti, n_fi,
 #                      n_a):
 #     """Go from a column-like input to a (ti, fi, a, c) output."""
@@ -65,7 +68,7 @@ gain_schema = ("rowlike", "chan", "ant", "dir", "corr")
 #     out_arr[t_m, f_m, a2_m, :] += in_col[row, chan, :].conjugate()
 
 
-@jit(nopython=True, fastmath=False, parallel=False, cache=True, nogil=True)
+@njit(**JIT_OPTIONS)
 def rfc_to_tfac(in_col, ant1_col, ant2_col, utime_ind, n_ut, n_a):
     """Accumulate a (r, f, c) column into (t, f, a, c) array."""
 
@@ -130,7 +133,7 @@ def get_output_dtype_impl(in_col):
         return lambda in_col: in_col.dtype
 
 
-# @jit(nopython=True, fastmath=False, parallel=False, cache=True, nogil=True)
+# @njit(**JIT_OPTIONS)
 # def rfdc_to_tfadc(in_col, ant1_col, ant2_col, utime_ind, n_ut, n_a):
 #     """Accumulate a (r, f, d, c) column into (t, f, a, d, c) array."""
 
@@ -159,7 +162,7 @@ def get_output_dtype_impl(in_col):
 #     return out_arr
 
 
-@jit(nopython=True, fastmath=False, parallel=False, cache=True, nogil=True)
+@njit(**JIT_OPTIONS)
 def rfdc_to_abs_tfadc(in_col, ant1_col, ant2_col, utime_ind, n_ut, n_a):
     """Accumulate (r, f, d, c) column into abs**2 (t, f, a, d, c) array."""
 
@@ -190,7 +193,7 @@ def rfdc_to_abs_tfadc(in_col, ant1_col, ant2_col, utime_ind, n_ut, n_a):
     return out_arr
 
 
-@jit(nopython=True, fastmath=False, parallel=False, cache=True, nogil=True)
+@njit(**JIT_OPTIONS)
 def tfx_to_tifix(in_arr, t_map, f_map):
     """Sum a (t, f, ...) array into a (ti, fi, ...) array."""
 

--- a/quartical/utils/maths.py
+++ b/quartical/utils/maths.py
@@ -1,7 +1,7 @@
 import numba as nb
 import numpy as np
-from numba import jit
-import math
+from numba import njit
+from quartical.utils.numba import JIT_OPTIONS
 
 
 @nb.vectorize([nb.float64(nb.complex128), nb.float32(nb.complex64)])
@@ -44,7 +44,7 @@ def arr_gcd(arr):
     return net_gcd
 
 
-@jit(nopython=True, fastmath=True, parallel=False, cache=True, nogil=True)
+@njit(**JIT_OPTIONS)
 def mean_for_index(arr, inds):
 
     sums = np.zeros(np.max(inds) + 1, dtype=arr.dtype)

--- a/quartical/utils/numba.py
+++ b/quartical/utils/numba.py
@@ -1,5 +1,20 @@
+from numba import njit
 from numba.core.extending import SentryLiteralArgs
 import inspect
+
+JIT_OPTIONS = {
+    "nogil": True,
+    "fastmath": True,
+    "cache": True
+}
+
+PARALLEL_JIT_OPTIONS = {
+    **JIT_OPTIONS,
+    "parallel": True
+}
+
+qcnjit = njit(**JIT_OPTIONS)
+qcnjit_parallel = njit(**PARALLEL_JIT_OPTIONS)
 
 
 def coerce_literal(func, literals):

--- a/quartical/utils/numba.py
+++ b/quartical/utils/numba.py
@@ -1,4 +1,3 @@
-from numba import njit
 from numba.core.extending import SentryLiteralArgs
 import inspect
 
@@ -12,9 +11,6 @@ PARALLEL_JIT_OPTIONS = {
     **JIT_OPTIONS,
     "parallel": True
 }
-
-qcnjit = njit(**JIT_OPTIONS)
-qcnjit_parallel = njit(**PARALLEL_JIT_OPTIONS)
 
 
 def coerce_literal(func, literals):

--- a/quartical/weights/robust.py
+++ b/quartical/weights/robust.py
@@ -1,22 +1,22 @@
 import numpy as np
-from numba import generated_jit, jit
+from numba import njit
+from numba.extending import overload
+from quartical.utils.numba import coerce_literal, JIT_OPTIONS
 import quartical.gains.general.factories as factories
 from quartical.gains.general.generics import compute_residual
 
 
-qcgjit = generated_jit(nopython=True,
-                       fastmath=True,
-                       cache=True,
-                       nogil=True)
-
-qcjit = jit(nopython=True,
-            fastmath=True,
-            cache=True,
-            nogil=True)
-
-
-@qcgjit
+@njit(**JIT_OPTIONS)
 def update_icovariance(residuals, flags, etas, icovariance, mode):
+    return update_icovariance_impl(residuals, flags, etas, icovariance, mode)
+
+
+def update_icovariance_impl(residuals, flags, etas, icovariance, mode):
+    raise NotImplementedError
+
+
+@overload(update_icovariance_impl, jit_options=JIT_OPTIONS)
+def nb_update_icovariance_impl(residuals, flags, etas, icovariance, mode):
 
     update_covariance_inner = update_covariance_inner_factory(mode)
 
@@ -76,11 +76,20 @@ def update_covariance_inner_factory(mode):
     else:
         raise ValueError("Unsupported number of correlations.")
 
-    return qcjit(impl)
+    return factories.qcjit(impl)
 
 
-@qcgjit
+@njit(**JIT_OPTIONS)
 def update_etas(residuals, flags, etas, icovariance, dof, mode):
+    return update_etas_impl(residuals, flags, etas, icovariance, dof, mode)
+
+
+def update_etas_impl(residuals, flags, etas, icovariance, dof, mode):
+    raise NotImplementedError
+
+
+@overload(update_etas_impl, jit_options=JIT_OPTIONS)
+def nb_update_etas_impl(residuals, flags, etas, icovariance, dof, mode):
 
     update_etas_inner = update_etas_inner_factory(mode)
 
@@ -133,10 +142,10 @@ def update_etas_inner_factory(mode):
     else:
         raise ValueError("Unsupported number of correlations.")
 
-    return qcjit(impl)
+    return factories.qcjit(impl)
 
 
-@qcjit
+@njit(**JIT_OPTIONS)
 def digamma(x):
 
     result = 0
@@ -154,12 +163,12 @@ def digamma(x):
     return result
 
 
-@qcjit
+@njit(**JIT_OPTIONS)
 def dof_variable(dof):
     return np.log(dof) - digamma(dof)
 
 
-@qcjit
+@njit(**JIT_OPTIONS)
 def dof_constant(etas, flags, dof, n_corr):
 
     n_row, n_chan = etas.shape
@@ -182,7 +191,7 @@ def dof_constant(etas, flags, dof, n_corr):
     return constant + 1 + digamma(dof + n_corr) - np.log(dof + n_corr)
 
 
-@qcjit
+@njit(**JIT_OPTIONS)
 def compute_dof(etas, flags, dof, n_corr):
 
     constant = dof_constant(etas, flags, dof, n_corr)
@@ -206,7 +215,7 @@ def compute_dof(etas, flags, dof, n_corr):
     return mid
 
 
-@qcjit
+@njit(**JIT_OPTIONS)
 def mean_weight(weights, flags):
 
     n_row, n_chan, n_corr = weights.shape
@@ -230,7 +239,7 @@ def mean_weight(weights, flags):
     return mean
 
 
-@qcjit
+@njit(**JIT_OPTIONS)
 def update_weights(weights, etas, icovariance):
 
     n_row, n_chan, n_corr = weights.shape
@@ -242,7 +251,7 @@ def update_weights(weights, etas, icovariance):
                 weights[r, f, c] = etas[r, f] * icovariance[c]
 
 
-@qcgjit
+@njit(**JIT_OPTIONS)
 def robust_reweighting(
     ms_inputs,
     mapping_inputs,
@@ -252,6 +261,41 @@ def robust_reweighting(
     dof,
     corr_mode
 ):
+    return robust_reweighting_impl(
+        ms_inputs,
+        mapping_inputs,
+        chain_inputs,
+        etas,
+        icovariance,
+        dof,
+        corr_mode
+    )
+
+
+def robust_reweighting_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    etas,
+    icovariance,
+    dof,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(robust_reweighting_impl, jit_options=JIT_OPTIONS)
+def nb_robust_reweighting_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    etas,
+    icovariance,
+    dof,
+    corr_mode
+):
+
+    coerce_literal(nb_robust_reweighting_impl, ["corr_mode"])
 
     def impl(
         ms_inputs,

--- a/testing/utils/gains.py
+++ b/testing/utils/gains.py
@@ -1,13 +1,23 @@
 import numpy as np
-from numba import generated_jit
+from numba import njit
+from numba.extending import overload
+from quartical.utils.numba import coerce_literal, JIT_OPTIONS
 import quartical.gains.general.factories as factories
-from quartical.utils.numba import coerce_literal
 
 
-@generated_jit(nopython=True, nogil=True, cache=True)
+@njit(**JIT_OPTIONS)
 def apply_gains(model, gains, ant1, ant2, row_ind, mode):
+    return apply_gains_impl(model, gains, ant1, ant2, row_ind, mode)
 
-    coerce_literal(apply_gains, ["mode"])
+
+def apply_gains_impl(model, gains, ant1, ant2, row_ind, mode):
+    raise NotImplementedError
+
+
+@overload(apply_gains_impl, jit_options=JIT_OPTIONS)
+def nb_apply_gains_impl(model, gains, ant1, ant2, row_ind, mode):
+
+    coerce_literal(nb_apply_gains_impl, ["mode"])
 
     v1_imul_v2 = factories.v1_imul_v2_factory(mode)
     v1_imul_v2ct = factories.v1_imul_v2ct_factory(mode)
@@ -43,10 +53,19 @@ def apply_gains(model, gains, ant1, ant2, row_ind, mode):
     return impl
 
 
-@generated_jit(nopython=True, nogil=True, cache=True)
+@njit(**JIT_OPTIONS)
 def reference_gains(gains, mode):
+    return reference_gains_impl(gains, mode)
 
-    coerce_literal(reference_gains, ["mode"])
+
+def reference_gains_impl(gains, mode):
+    raise NotImplementedError
+
+
+@overload(reference_gains_impl, jit_options=JIT_OPTIONS)
+def nb_reference_gains_impl(gains, mode):
+
+    coerce_literal(nb_reference_gains_impl, ["mode"])
 
     v1_imul_v2 = factories.v1_imul_v2_factory(mode)
     compute_det = factories.compute_det_factory(mode)


### PR DESCRIPTION
This is still in a WIP but I wanted to get the tests firing off as I change things - I have already made changes to a large amount of the code but some modules still need to be migrated. `@overload` is pretty much a drop in replacement in most cases. The awkward case is functions which were previously wrapped with `@generated_jit` and are called from Python. An overload only works when the called from a jitted function. This means that you can end up with the following:

```python
from numba import njit
from numba.extending import overload

@njit
def f(*args):  # Can be called from Python.
    return f_impl(*args)

def f_impl(*args):
    raise NotImplementedError

@overload(f_impl)
def nb_f_impl(*args):
    def impl(*args):
        return len(args)
    return impl

f(1, 2, 3)  # Will work.
f_impl(1, 2, 3)  # Raises NotImplementedError
```
Given that typically we don't have `*args` functions signatures, this can get very verbose for complicated functions. I am not sure if there is an alternative, but it is worth noting that this does create a monstrous amount of boilerplate.

Edit: As always, I may have missed something - will think about it/check.