### PR TITLE
Add antenna referencing to diagonal terms

### DIFF
--- a/quartical/calibration/solver.py
+++ b/quartical/calibration/solver.py
@@ -18,6 +18,7 @@ meta_args_nt = namedtuple(
         "stop_crit",
         "threads",
         "robust",
+        "reference_antenna",
         "dd_term",
         "pinned_directions",
         "solve_per",
@@ -238,6 +239,7 @@ def solver_wrapper(
             solver_opts.convergence_criteria,
             solver_opts.threads,
             solver_opts.robust,
+            solver_opts.reference_antenna,
             term.direction_dependent,
             term.pinned_directions,
             term.solve_per

--- a/quartical/config/argument_schema.yaml
+++ b/quartical/config/argument_schema.yaml
@@ -377,10 +377,10 @@ solver:
     dtype: int
     default: 0
     info:
-      A reference antenna to use for terms which require one. This is shared
-      by all terms and currently only used for delay estimates - QuartiCal
-      does not guarantee zero phase on an antenna. Specify as the integer
-      index of the antenna - antenna names are not currently supported.
+      A reference antenna to use for terms which require one. QuartiCal will
+      also guarantee zero phase on the specified antenna for diagonal terms.
+      Specify as the integer index of the antenna - antenna names are not
+      currently supported.
 
 dask:
   threads:

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -198,6 +198,13 @@ def nb_delay_solver_impl(
             corr_mode
         )
 
+        reference_params(
+            mapping_inputs,
+            chain_inputs,
+            meta_inputs,
+            scaled_cf
+        )
+
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
@@ -817,3 +824,55 @@ def delay_params_to_gains(
 
                     if n_corr > 1:
                         g[-1] = np.exp(1j*2*np.pi*(cf*p[3] + p[2]))
+
+
+@njit(**JIT_OPTIONS)
+def reference_params(mapping_inputs, chain_inputs, meta_inputs, chan_freq):
+
+    active_term = meta_inputs.active_term
+    ref_ant = meta_inputs.reference_antenna
+
+    gains = chain_inputs.gains[active_term]
+    params = chain_inputs.params[active_term]
+    param_flags = chain_inputs.param_flags[active_term]
+    gain_flags = chain_inputs.gain_flags[active_term]
+
+    param_freq_map = mapping_inputs.param_freq_maps[active_term]
+
+    n_ti, n_fi, n_ant, n_dir, n_corr = params.shape
+
+    ref_params = params[:, :, ref_ant: ref_ant + 1, :, :].copy()
+
+    for t in range(n_ti):
+        for f in range(n_fi):
+            for a in range(n_ant):
+                for d in range(n_dir):
+
+                    p = params[t, f, a, d]
+                    rp = ref_params[t, f, 0, d]
+
+                    if param_flags[t, f, a, d] == 1:
+                        continue
+                    else:
+                        p -= rp
+
+    n_time, n_freq, n_ant, n_dir, n_corr = gains.shape
+
+    for t in range(n_time):
+        for f in range(n_freq):
+            cf = chan_freq[f]
+            f_m = param_freq_map[f]
+            for a in range(n_ant):
+                for d in range(n_dir):
+
+                    g = gains[t, f, a, d]
+                    p = params[t, f_m, a, d]
+                    gf = gain_flags[t, f, a, d]
+
+                    if gf == 1:
+                        continue
+
+                    g[0] = np.exp(1j*(cf*p[1] + p[0]))
+
+                    if n_corr > 1:
+                        g[-1] = np.exp(1j*(cf*p[3] + p[2]))

--- a/quartical/gains/delay/pure_kernel.py
+++ b/quartical/gains/delay/pure_kernel.py
@@ -23,7 +23,8 @@ from quartical.gains.general.convenience import (
 from quartical.gains.delay.kernel import (
     compute_jhj_jhr,
     compute_update,
-    finalize_update
+    finalize_update,
+    reference_params
 )
 
 
@@ -206,6 +207,13 @@ def nb_pure_delay_solver_impl(
             meta_inputs,
             flag_imdry,
             corr_mode
+        )
+
+        reference_params(
+            mapping_inputs,
+            chain_inputs,
+            meta_inputs,
+            scaled_cf
         )
 
         # Call this one last time to ensure points flagged by finialize are

--- a/quartical/gains/phase/kernel.py
+++ b/quartical/gains/phase/kernel.py
@@ -190,6 +190,8 @@ def nb_phase_solver_impl(
             corr_mode
         )
 
+        # reference_params(chain_inputs, meta_inputs)
+
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
@@ -738,3 +740,51 @@ def phase_params_to_gains(
 
                     if n_corr > 1:
                         g[-1] = np.exp(1j*p[-1])
+
+
+@njit(**JIT_OPTIONS)
+def reference_params(chain_inputs, meta_inputs):
+
+    active_term = meta_inputs.active_term
+    ref_ant = meta_inputs.reference_antenna
+
+    gains = chain_inputs.gains[active_term]
+    params = chain_inputs.params[active_term]
+    param_flags = chain_inputs.param_flags[active_term]
+    gain_flags = chain_inputs.gain_flags[active_term]
+
+    n_ti, n_fi, n_ant, n_dir, n_corr = params.shape
+
+    ref_params = params[:, :, ref_ant: ref_ant + 1, :, :].copy()
+
+    for t in range(n_ti):
+        for f in range(n_fi):
+            for a in range(n_ant):
+                for d in range(n_dir):
+
+                    p = params[t, f, a, d]
+                    rp = ref_params[t, f, 0, d]
+
+                    if param_flags[t, f, a, d] == 1:
+                        continue
+                    else:
+                        p -= rp
+
+    n_time, n_freq, n_ant, n_dir, n_corr = gains.shape
+
+    for t in range(n_time):
+        for f in range(n_freq):
+            for a in range(n_ant):
+                for d in range(n_dir):
+
+                    g = gains[t, f, a, d]
+                    p = params[t, f, a, d]
+                    gf = gain_flags[t, f, a, d]
+
+                    if gf == 1:
+                        continue
+
+                    g[0] = np.exp(1j*p[0])
+
+                    if n_corr > 1:
+                        g[-1] = np.exp(1j*p[1])


### PR DESCRIPTION
Should do what it says on the label. For now, the implementation assumes that the reference antenna is always present. Dealing with a heavily flagged reference antenna is challenging and I haven't thought of an adequate solution yet.

This will guarantee zero phase on the reference antenna which is important for X/D calibration.