### PR TITLE
Fix incorrect code when initialising gains from params for delay/pure_delay/tec.

### DIFF
--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -820,10 +820,10 @@ def delay_params_to_gains(
                     g = gains[t, f, a, d]
                     p = params[t, f_m, a, d]
 
-                    g[0] = np.exp(1j*2*np.pi*(cf*p[1] + p[0]))
+                    g[0] = np.exp(1j*(2*np.pi*cf*p[1] + p[0]))
 
                     if n_corr > 1:
-                        g[-1] = np.exp(1j*2*np.pi*(cf*p[3] + p[2]))
+                        g[-1] = np.exp(1j*(2*np.pi*cf*p[3] + p[2]))
 
 
 @njit(**JIT_OPTIONS)

--- a/quartical/gains/tec/kernel.py
+++ b/quartical/gains/tec/kernel.py
@@ -242,10 +242,10 @@ def tec_params_to_gains(
                     g = gains[t, f, a, d]
                     p = params[t, f_m, a, d]
 
-                    g[0] = np.exp(1j*2*np.pi*(icf*p[1] + p[0]))
+                    g[0] = np.exp(1j*(2*np.pi*icf*p[1] + p[0]))
 
                     if n_corr > 1:
-                        g[-1] = np.exp(1j*2*np.pi*(icf*p[3] + p[2]))
+                        g[-1] = np.exp(1j*(2*np.pi*icf*p[3] + p[2]))
 
 
 @njit(**JIT_OPTIONS)


### PR DESCRIPTION
@landmanbester As it says on the label - incorrect brackets led to evaluated gains being wrong. This could have caused major issues when used in a chain.