### PR TITLE
Improve gain/flagging consistency

### DIFF
--- a/quartical/calibration/constructor.py
+++ b/quartical/calibration/constructor.py
@@ -139,7 +139,7 @@ def construct_solver(
         for term_name, term_xds in gain_terms.items():
 
             blocker.add_output(
-                f"{term_name}_gain",
+                f"{term_name}_gains",
                 ("row", "chan", "ant", "dir", "corr"),
                 term_xds.GAIN_SPEC,
                 np.complex128
@@ -155,7 +155,7 @@ def construct_solver(
             # If there is a PARAM_SPEC on the gain xds, it is also an output.
             if hasattr(term_xds, "PARAM_SPEC"):
                 blocker.add_output(
-                    f"{term_name}_param",
+                    f"{term_name}_params",
                     ("row", "chan", "ant", "dir", "param"),
                     term_xds.PARAM_SPEC,
                     np.float64
@@ -228,7 +228,7 @@ def construct_solver(
 
             result_vars = {}
 
-            gain = output_dict[f"{term_name}_gain"]
+            gain = output_dict[f"{term_name}_gains"]
             result_vars["gains"] = (term_xds.GAIN_AXES, gain)
 
             flags = output_dict[f"{term_name}_gain_flags"]
@@ -241,7 +241,7 @@ def construct_solver(
             result_vars["conv_iter"] = (("time_chunk", "freq_chunk"), conviter)
 
             if hasattr(term_xds, "PARAM_SPEC"):
-                params = output_dict[f"{term_name}_param"]
+                params = output_dict[f"{term_name}_params"]
                 result_vars["params"] = (term_xds.PARAM_AXES, params)
 
                 param_flags = output_dict[f"{term_name}_param_flags"]

--- a/quartical/calibration/solver.py
+++ b/quartical/calibration/solver.py
@@ -268,6 +268,7 @@ def solver_wrapper(
         mapping_kwargs["dir_maps"],
         corr_mode
     )
+
     log_chisq(presolve_chisq, postsolve_chisq, aux_block_info, block_id)
 
     results_dict["presolve_chisq"] = presolve_chisq

--- a/quartical/gains/amplitude/__init__.py
+++ b/quartical/gains/amplitude/__init__.py
@@ -5,6 +5,10 @@ from quartical.gains.amplitude.kernel import (
     amplitude_solver,
     amplitude_params_to_gains
 )
+from quartical.gains.general.flagging import (
+    apply_gain_flags_to_gains,
+    apply_param_flags_to_params
+)
 
 
 class Amplitude(ParameterizedGain):
@@ -37,7 +41,7 @@ class Amplitude(ParameterizedGain):
     def init_term(self, term_spec, ref_ant, ms_kwargs, term_kwargs):
         """Initialise the gains (and parameters)."""
 
-        gains, params = super().init_term(
+        gains, gain_flags, params, param_flags = super().init_term(
             term_spec, ref_ant, ms_kwargs, term_kwargs
         )
 
@@ -47,4 +51,8 @@ class Amplitude(ParameterizedGain):
         # Convert the parameters into gains.
         amplitude_params_to_gains(params, gains)
 
-        return gains, params
+        # Apply flags to gains and parameters.
+        apply_param_flags_to_params(param_flags, params, 1)
+        apply_gain_flags_to_gains(gain_flags, gains)
+
+        return gains, gain_flags, params, param_flags

--- a/quartical/gains/amplitude/kernel.py
+++ b/quartical/gains/amplitude/kernel.py
@@ -13,7 +13,7 @@ from quartical.gains.general.generics import (native_intermediaries,
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
-                                              apply_gain_flags,
+                                              apply_gain_flags_to_flag_col,
                                               update_param_flags)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
@@ -192,7 +192,7 @@ def nb_amplitude_solver_impl(
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
-            apply_gain_flags(
+            apply_gain_flags_to_flag_col(
                 ms_inputs,
                 mapping_inputs,
                 chain_inputs,

--- a/quartical/gains/complex/diag_kernel.py
+++ b/quartical/gains/complex/diag_kernel.py
@@ -13,7 +13,7 @@ from quartical.gains.general.generics import (native_intermediaries,
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
-                                              apply_gain_flags)
+                                              apply_gain_flags_to_flag_col)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
 import quartical.gains.general.factories as factories
@@ -170,7 +170,7 @@ def nb_diag_complex_solver_impl(
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
-            apply_gain_flags(
+            apply_gain_flags_to_flag_col(
                 ms_inputs,
                 mapping_inputs,
                 chain_inputs,

--- a/quartical/gains/complex/diag_kernel.py
+++ b/quartical/gains/complex/diag_kernel.py
@@ -13,7 +13,8 @@ from quartical.gains.general.generics import (native_intermediaries,
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
-                                              apply_gain_flags_to_flag_col)
+                                              apply_gain_flags_to_flag_col,
+                                              apply_gain_flags_to_gains)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
 import quartical.gains.general.factories as factories
@@ -637,7 +638,7 @@ def nb_reference_gains_impl(chain_inputs, meta_inputs, mode):
         ref_ant = meta_inputs.reference_antenna
 
         gains = chain_inputs.gains[active_term]
-        flags = chain_inputs.gain_flags[active_term]
+        gain_flags = chain_inputs.gain_flags[active_term]
 
         n_ti, n_fi, n_ant, n_dir, n_corr = gains.shape
 
@@ -647,7 +648,7 @@ def nb_reference_gains_impl(chain_inputs, meta_inputs, mode):
             for f in range(n_fi):
                 for d in range(n_dir):
 
-                    if flags[t, f, ref_ant, d]:  # TODO: Flagged refant?
+                    if gain_flags[t, f, ref_ant, d]:  # TODO: Flagged refant?
                         continue
                     elif n_corr in (1, 2):
                         rg = ref_gains[t, f, 0, d]
@@ -666,5 +667,7 @@ def nb_reference_gains_impl(chain_inputs, meta_inputs, mode):
                         rg = ref_gains[t, f, 0, d]
 
                         v1_imul_v2(g, rg, g)
+
+        apply_gain_flags_to_gains(gain_flags, gains)
 
     return impl

--- a/quartical/gains/complex/kernel.py
+++ b/quartical/gains/complex/kernel.py
@@ -13,7 +13,7 @@ from quartical.gains.general.generics import (native_intermediaries,
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
-                                              apply_gain_flags)
+                                              apply_gain_flags_to_flag_col)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
 import quartical.gains.general.factories as factories
@@ -172,7 +172,7 @@ def nb_complex_solver_impl(
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
-            apply_gain_flags(
+            apply_gain_flags_to_flag_col(
                 ms_inputs,
                 mapping_inputs,
                 chain_inputs,

--- a/quartical/gains/crosshand_phase/__init__.py
+++ b/quartical/gains/crosshand_phase/__init__.py
@@ -5,6 +5,10 @@ from quartical.gains.crosshand_phase.kernel import (
     crosshand_phase_solver,
     crosshand_params_to_gains
 )
+from quartical.gains.general.flagging import (
+    apply_gain_flags_to_gains,
+    apply_param_flags_to_params
+)
 
 
 class CrosshandPhase(ParameterizedGain):
@@ -38,11 +42,15 @@ class CrosshandPhase(ParameterizedGain):
     def init_term(self, term_spec, ref_ant, ms_kwargs, term_kwargs):
         """Initialise the gains (and parameters)."""
 
-        gains, params = super().init_term(
+        gains, gain_flags, params, param_flags = super().init_term(
             term_spec, ref_ant, ms_kwargs, term_kwargs
         )
 
         # Convert the parameters into gains.
         crosshand_params_to_gains(params, gains)
 
-        return gains, params
+        # Apply flags to gains and parameters.
+        apply_param_flags_to_params(param_flags, params, 0)
+        apply_gain_flags_to_gains(gain_flags, gains)
+
+        return gains, gain_flags, params, param_flags

--- a/quartical/gains/crosshand_phase/kernel.py
+++ b/quartical/gains/crosshand_phase/kernel.py
@@ -13,7 +13,7 @@ from quartical.gains.general.generics import (native_intermediaries,
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
-                                              apply_gain_flags,
+                                              apply_gain_flags_to_flag_col,
                                               update_param_flags)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
@@ -190,7 +190,7 @@ def nb_crosshand_phase_solver_impl(
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
-            apply_gain_flags(
+            apply_gain_flags_to_flag_col(
                 ms_inputs,
                 mapping_inputs,
                 chain_inputs,

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -18,7 +18,7 @@ from quartical.gains.general.flagging import (
     flag_intermediaries,
     update_gain_flags,
     finalize_gain_flags,
-    apply_gain_flags,
+    apply_gain_flags_to_flag_col,
     update_param_flags
 )
 from quartical.gains.general.convenience import (get_row,
@@ -213,7 +213,7 @@ def nb_delay_solver_impl(
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
-            apply_gain_flags(
+            apply_gain_flags_to_flag_col(
                 ms_inputs,
                 mapping_inputs,
                 chain_inputs,

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -19,7 +19,9 @@ from quartical.gains.general.flagging import (
     update_gain_flags,
     finalize_gain_flags,
     apply_gain_flags_to_flag_col,
-    update_param_flags
+    update_param_flags,
+    apply_gain_flags_to_gains,
+    apply_param_flags_to_params
 )
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
@@ -822,6 +824,7 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
     ref_ant = meta_inputs.reference_antenna
 
     gains = chain_inputs.gains[active_term]
+    gain_flags = chain_inputs.gain_flags[active_term]
     params = chain_inputs.params[active_term]
     param_flags = chain_inputs.param_flags[active_term]
 
@@ -847,3 +850,7 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
     delay_params_to_gains(
         params, gains, chan_freq, param_freq_map, rescaled=True
     )
+
+    # Referencing may move flagged gains/params from identity.
+    apply_param_flags_to_params(param_flags, params, 0)
+    apply_gain_flags_to_gains(gain_flags, gains)

--- a/quartical/gains/delay_and_offset/__init__.py
+++ b/quartical/gains/delay_and_offset/__init__.py
@@ -6,6 +6,10 @@ from quartical.gains.delay_and_offset.kernel import (
     delay_and_offset_solver,
     delay_and_offset_params_to_gains
 )
+from quartical.gains.general.flagging import (
+    apply_gain_flags_to_gains,
+    apply_param_flags_to_params
+)
 
 # Overload the default measurement set inputs to include the frequencies.
 ms_inputs = namedtuple(
@@ -54,20 +58,24 @@ class DelayAndOffset(ParameterizedGain):
     def init_term(self, term_spec, ref_ant, ms_kwargs, term_kwargs):
         """Initialise the gains (and parameters)."""
 
-        gain, param = super().init_term(
+        gains, gain_flags, params, param_flags = super().init_term(
             term_spec, ref_ant, ms_kwargs, term_kwargs
         )
 
         # Convert the parameters into gains.
         delay_and_offset_params_to_gains(
-            param,
-            gain,
+            params,
+            gains,
             ms_kwargs["CHAN_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 
         if self.load_from or not self.initial_estimate:
-            return gain, param
+
+            apply_param_flags_to_params(param_flags, params, 0)
+            apply_gain_flags_to_gains(gain_flags, gains)
+
+            return gains, gain_flags, params, param_flags
 
         data = ms_kwargs["DATA"]  # (row, chan, corr)
         flags = ms_kwargs["FLAG"]  # (row, chan)
@@ -76,7 +84,7 @@ class DelayAndOffset(ParameterizedGain):
         chan_freq = ms_kwargs["CHAN_FREQ"]
         t_map = term_kwargs[f"{term_spec.name}_time_map"]
         f_map = term_kwargs[f"{term_spec.name}_param_freq_map"]
-        _, n_chan, n_ant, n_dir, n_corr = gain.shape
+        _, n_chan, n_ant, n_dir, n_corr = gains.shape
 
         # We only need the baselines which include the ref_ant.
         sel = np.where((a1 == ref_ant) | (a2 == ref_ant))
@@ -145,19 +153,22 @@ class DelayAndOffset(ParameterizedGain):
 
                 for t, p, q in zip(t_map[sel], a1[sel], a2[sel]):
                     if p == ref_ant:
-                        param[t, uf, q, 0, 1] = -delay_est_00[q]
+                        params[t, uf, q, 0, 1] = -delay_est_00[q]
                         if n_corr > 1:
-                            param[t, uf, q, 0, 3] = -delay_est_11[q]
+                            params[t, uf, q, 0, 3] = -delay_est_11[q]
                     else:
-                        param[t, uf, p, 0, 1] = delay_est_00[p]
+                        params[t, uf, p, 0, 1] = delay_est_00[p]
                         if n_corr > 1:
-                            param[t, uf, p, 0, 3] = delay_est_11[p]
+                            params[t, uf, p, 0, 3] = delay_est_11[p]
 
         delay_and_offset_params_to_gains(
-            param,
-            gain,
+            params,
+            gains,
             ms_kwargs["CHAN_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 
-        return gain, param
+        apply_param_flags_to_params(param_flags, params, 0)
+        apply_gain_flags_to_gains(gain_flags, gains)
+
+        return gains, gain_flags, params, param_flags

--- a/quartical/gains/delay_and_offset/kernel.py
+++ b/quartical/gains/delay_and_offset/kernel.py
@@ -14,7 +14,9 @@ from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
                                               apply_gain_flags_to_flag_col,
-                                              update_param_flags)
+                                              update_param_flags,
+                                              apply_gain_flags_to_gains,
+                                              apply_param_flags_to_params)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
 import quartical.gains.general.factories as factories
@@ -855,6 +857,7 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
     ref_ant = meta_inputs.reference_antenna
 
     gains = chain_inputs.gains[active_term]
+    gain_flags = chain_inputs.gain_flags[active_term]
     params = chain_inputs.params[active_term]
     param_flags = chain_inputs.param_flags[active_term]
 
@@ -880,3 +883,7 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
     delay_and_offset_params_to_gains(
         params, gains, chan_freq, param_freq_map, rescaled=True
     )
+
+    # Referencing may move flagged gains/params from identity.
+    apply_param_flags_to_params(param_flags, params, 0)
+    apply_gain_flags_to_gains(gain_flags, gains)

--- a/quartical/gains/delay_and_offset/kernel.py
+++ b/quartical/gains/delay_and_offset/kernel.py
@@ -13,7 +13,7 @@ from quartical.gains.general.generics import (native_intermediaries,
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
-                                              apply_gain_flags,
+                                              apply_gain_flags_to_flag_col,
                                               update_param_flags)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
@@ -207,7 +207,7 @@ def nb_delay_and_offset_solver_impl(
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
-            apply_gain_flags(
+            apply_gain_flags_to_flag_col(
                 ms_inputs,
                 mapping_inputs,
                 chain_inputs,

--- a/quartical/gains/leakage/kernel.py
+++ b/quartical/gains/leakage/kernel.py
@@ -11,7 +11,7 @@ from quartical.gains.general.generics import (native_intermediaries,
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
-                                              apply_gain_flags)
+                                              apply_gain_flags_to_flag_col)
 from quartical.gains.general.convenience import get_extents
 import quartical.gains.general.factories as factories
 from quartical.gains.complex.kernel import (get_jhj_dims_factory,
@@ -169,7 +169,7 @@ def nb_leakage_solver_impl(
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
-            apply_gain_flags(
+            apply_gain_flags_to_flag_col(
                 ms_inputs,
                 mapping_inputs,
                 chain_inputs,

--- a/quartical/gains/phase/__init__.py
+++ b/quartical/gains/phase/__init__.py
@@ -5,6 +5,10 @@ from quartical.gains.phase.kernel import (
     phase_solver,
     phase_params_to_gains
 )
+from quartical.gains.general.flagging import (
+    apply_gain_flags_to_gains,
+    apply_param_flags_to_params
+)
 
 
 class Phase(ParameterizedGain):
@@ -38,11 +42,15 @@ class Phase(ParameterizedGain):
     def init_term(self, term_spec, ref_ant, ms_kwargs, term_kwargs):
         """Initialise the gains (and parameters)."""
 
-        gains, params = super().init_term(
+        gains, gain_flags, params, param_flags = super().init_term(
             term_spec, ref_ant, ms_kwargs, term_kwargs
         )
 
         # Convert the parameters into gains.
         phase_params_to_gains(params, gains)
 
-        return gains, params
+        # Apply flags to gains and parameters.
+        apply_param_flags_to_params(param_flags, params, 1)
+        apply_gain_flags_to_gains(gain_flags, gains)
+
+        return gains, gain_flags, params, param_flags

--- a/quartical/gains/phase/kernel.py
+++ b/quartical/gains/phase/kernel.py
@@ -13,7 +13,7 @@ from quartical.gains.general.generics import (native_intermediaries,
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
-                                              apply_gain_flags,
+                                              apply_gain_flags_to_flag_col,
                                               update_param_flags)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
@@ -195,7 +195,7 @@ def nb_phase_solver_impl(
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
-            apply_gain_flags(
+            apply_gain_flags_to_flag_col(
                 ms_inputs,
                 mapping_inputs,
                 chain_inputs,

--- a/quartical/gains/phase/kernel.py
+++ b/quartical/gains/phase/kernel.py
@@ -14,7 +14,9 @@ from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
                                               apply_gain_flags_to_flag_col,
-                                              update_param_flags)
+                                              update_param_flags,
+                                              apply_gain_flags_to_gains,
+                                              apply_param_flags_to_params)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
 import quartical.gains.general.factories as factories
@@ -190,7 +192,7 @@ def nb_phase_solver_impl(
             corr_mode
         )
 
-        # reference_params(chain_inputs, meta_inputs)
+        reference_params(chain_inputs, meta_inputs)
 
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
@@ -749,9 +751,9 @@ def reference_params(chain_inputs, meta_inputs):
     ref_ant = meta_inputs.reference_antenna
 
     gains = chain_inputs.gains[active_term]
+    gain_flags = chain_inputs.gain_flags[active_term]
     params = chain_inputs.params[active_term]
     param_flags = chain_inputs.param_flags[active_term]
-    gain_flags = chain_inputs.gain_flags[active_term]
 
     n_ti, n_fi, n_ant, n_dir, n_corr = params.shape
 
@@ -770,21 +772,8 @@ def reference_params(chain_inputs, meta_inputs):
                     else:
                         p -= rp
 
-    n_time, n_freq, n_ant, n_dir, n_corr = gains.shape
+    phase_params_to_gains(params, gains)
 
-    for t in range(n_time):
-        for f in range(n_freq):
-            for a in range(n_ant):
-                for d in range(n_dir):
-
-                    g = gains[t, f, a, d]
-                    p = params[t, f, a, d]
-                    gf = gain_flags[t, f, a, d]
-
-                    if gf == 1:
-                        continue
-
-                    g[0] = np.exp(1j*p[0])
-
-                    if n_corr > 1:
-                        g[-1] = np.exp(1j*p[1])
+    # Referencing may move flagged gains/params from identity.
+    apply_param_flags_to_params(param_flags, params, 0)
+    apply_gain_flags_to_gains(gain_flags, gains)

--- a/quartical/gains/rotation/__init__.py
+++ b/quartical/gains/rotation/__init__.py
@@ -5,6 +5,10 @@ from quartical.gains.rotation.kernel import (
     rotation_solver,
     rotation_params_to_gains
 )
+from quartical.gains.general.flagging import (
+    apply_gain_flags_to_gains,
+    apply_param_flags_to_params
+)
 
 
 class Rotation(ParameterizedGain):
@@ -33,11 +37,15 @@ class Rotation(ParameterizedGain):
     def init_term(self, term_spec, ref_ant, ms_kwargs, term_kwargs):
         """Initialise the gains (and parameters)."""
 
-        gains, params = super().init_term(
+        gains, gain_flags, params, param_flags = super().init_term(
             term_spec, ref_ant, ms_kwargs, term_kwargs
         )
 
         # Convert the parameters into gains.
         rotation_params_to_gains(params, gains)
 
-        return gains, params
+        # Apply flags to gains and parameters.
+        apply_param_flags_to_params(param_flags, params, 1)
+        apply_gain_flags_to_gains(gain_flags, gains)
+
+        return gains, gain_flags, params, param_flags

--- a/quartical/gains/rotation/kernel.py
+++ b/quartical/gains/rotation/kernel.py
@@ -13,7 +13,7 @@ from quartical.gains.general.generics import (native_intermediaries,
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
-                                              apply_gain_flags,
+                                              apply_gain_flags_to_flag_col,
                                               update_param_flags)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
@@ -193,7 +193,7 @@ def nb_rotation_solver_impl(
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
-            apply_gain_flags(
+            apply_gain_flags_to_flag_col(
                 ms_inputs,
                 mapping_inputs,
                 chain_inputs,

--- a/quartical/gains/rotation_measure/__init__.py
+++ b/quartical/gains/rotation_measure/__init__.py
@@ -6,6 +6,10 @@ from quartical.gains.rotation_measure.kernel import (
     rm_solver,
     rm_params_to_gains
 )
+from quartical.gains.general.flagging import (
+    apply_gain_flags_to_gains,
+    apply_param_flags_to_params
+)
 
 # Overload the default measurement set inputs to include the frequencies.
 ms_inputs = namedtuple(
@@ -70,12 +74,12 @@ class RotationMeasure(ParameterizedGain):
     def init_term(self, term_spec, ref_ant, ms_kwargs, term_kwargs):
         """Initialise the gains (and parameters)."""
 
-        gains, params = super().init_term(
+        gains, gain_flags, params, param_flags = super().init_term(
             term_spec, ref_ant, ms_kwargs, term_kwargs
         )
 
         chan_freq = ms_kwargs["CHAN_FREQ"]
-        lambda_sq = (299792458/chan_freq)**2
+        lambda_sq = (299792458 / chan_freq) ** 2
 
         # Convert the parameters into gains.
         rm_params_to_gains(
@@ -85,4 +89,8 @@ class RotationMeasure(ParameterizedGain):
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 
-        return gains, params
+        # Apply flags to gains and parameters.
+        apply_param_flags_to_params(param_flags, params, 1)
+        apply_gain_flags_to_gains(gain_flags, gains)
+
+        return gains, gain_flags, params, param_flags

--- a/quartical/gains/rotation_measure/kernel.py
+++ b/quartical/gains/rotation_measure/kernel.py
@@ -13,7 +13,7 @@ from quartical.gains.general.generics import (native_intermediaries,
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
-                                              apply_gain_flags,
+                                              apply_gain_flags_to_flag_col,
                                               update_param_flags)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
@@ -197,7 +197,7 @@ def nb_rm_solver_impl(
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
-            apply_gain_flags(
+            apply_gain_flags_to_flag_col(
                 ms_inputs,
                 mapping_inputs,
                 chain_inputs,

--- a/quartical/gains/tec_and_offset/__init__.py
+++ b/quartical/gains/tec_and_offset/__init__.py
@@ -6,6 +6,10 @@ from quartical.gains.tec_and_offset.kernel import (
     tec_and_offset_solver,
     tec_and_offset_params_to_gains
 )
+from quartical.gains.general.flagging import (
+    apply_gain_flags_to_gains,
+    apply_param_flags_to_params
+)
 
 # Overload the default measurement set inputs to include the frequencies.
 ms_inputs = namedtuple(
@@ -54,7 +58,7 @@ class TecAndOffset(ParameterizedGain):
     def init_term(self, term_spec, ref_ant, ms_kwargs, term_kwargs):
         """Initialise the gains (and parameters)."""
 
-        gains, params = super().init_term(
+        gains, gain_flags, params, param_flags = super().init_term(
             term_spec, ref_ant, ms_kwargs, term_kwargs
         )
 
@@ -66,4 +70,8 @@ class TecAndOffset(ParameterizedGain):
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 
-        return gains, params
+        # Apply flags to gains and parameters.
+        apply_param_flags_to_params(param_flags, params, 1)
+        apply_gain_flags_to_gains(gain_flags, gains)
+
+        return gains, gain_flags, params, param_flags

--- a/quartical/gains/tec_and_offset/kernel.py
+++ b/quartical/gains/tec_and_offset/kernel.py
@@ -14,7 +14,9 @@ from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
                                               apply_gain_flags_to_flag_col,
-                                              update_param_flags)
+                                              update_param_flags,
+                                              apply_gain_flags_to_gains,
+                                              apply_param_flags_to_params)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
 import quartical.gains.general.factories as factories
@@ -859,6 +861,7 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
     ref_ant = meta_inputs.reference_antenna
 
     gains = chain_inputs.gains[active_term]
+    gain_flags = chain_inputs.gain_flags[active_term]
     params = chain_inputs.params[active_term]
     param_flags = chain_inputs.param_flags[active_term]
 
@@ -884,3 +887,7 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
     tec_and_offset_params_to_gains(
         params, gains, chan_freq, param_freq_map, rescaled=True
     )
+
+    # Referencing may move flagged gains/params from identity.
+    apply_param_flags_to_params(param_flags, params, 0)
+    apply_gain_flags_to_gains(gain_flags, gains)

--- a/quartical/gains/tec_and_offset/kernel.py
+++ b/quartical/gains/tec_and_offset/kernel.py
@@ -13,7 +13,7 @@ from quartical.gains.general.generics import (native_intermediaries,
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
-                                              apply_gain_flags,
+                                              apply_gain_flags_to_flag_col,
                                               update_param_flags)
 from quartical.gains.general.convenience import (get_row,
                                                  get_extents)
@@ -209,7 +209,7 @@ def nb_tec_and_offset_solver_impl(
         # Call this one last time to ensure points flagged by finialize are
         # propagated (in the DI case).
         if not dd_term:
-            apply_gain_flags(
+            apply_gain_flags_to_flag_col(
                 ms_inputs,
                 mapping_inputs,
                 chain_inputs,

--- a/quartical/statistics/logging.py
+++ b/quartical/statistics/logging.py
@@ -42,21 +42,28 @@ def log_chisq(pre, post, attrs, block_id=None):
     msg += f"T_CHUNK: {t_chunk} "
     msg += f"F_CHUNK: {f_chunk} "
 
-    if pre.item() == post.item():
-        colour = colours['yellow']
-    elif pre.item() > post.item():
-        colour = colours['green']
-    elif pre.item() < post.item():
-        colour = colours['red']
+    pre = pre.item()
+    post = post.item()
+
+    if np.isfinite(pre) and np.isfinite(post):
+        fractional_change = (post - pre) / pre
+    else:
+        fractional_change = np.nan
+
+    if np.isfinite(fractional_change):
+        if np.abs(fractional_change) < 1e-12:  # Slightly numb to jitter.
+            colour = colours['yellow']
+        elif fractional_change < 0:
+            colour = colours['green']
+        elif fractional_change > 0:
+            colour = colours['red']
     else:
         colour = colours['grey']
 
     co, cc = f"<fg #{colour}>", f"</fg #{colour}>"
-    msg += f"{co}CHISQ: {pre.item():.2f} -> {post.item():.2f}{cc}"
+    msg += f"{co}CHISQ: {pre:.2f} -> {post:.2f}{cc}"
 
     logger.opt(colors=True).info(msg)
-
-    return post.copy()
 
 
 def log_summary_stats(stats_xds_list):


### PR DESCRIPTION
This PR includes a migration of flag initialisation into the individual term inits. This is helpful as it means that all the required information to initialise a term correctly is available. Although what was already there was working, I was concerned that it could become an issue as QuartiCal grows. Terms should now reliably reset gains/params associated with flags and the behaviour of interpolated terms should match that of solved terms.