### PR TITLE
Use nearest-neighbour interpolation in regions where extrapolation is required.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quartical"
-version = "0.1.11"
+version = "0.2.0"
 description = "Fast and flexible calibration suite for radio interferometer data."
 repository = "https://github.com/ratt-ru/QuartiCal"
 documentation = "https://quartical.readthedocs.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quartical"
-version = "0.1.10"
+version = "0.1.11"
 description = "Fast and flexible calibration suite for radio interferometer data."
 repository = "https://github.com/ratt-ru/QuartiCal"
 documentation = "https://quartical.readthedocs.io"

--- a/tbump.toml
+++ b/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/ratt-ru/QuartiCal/"
 
 [version]
-current = "0.1.11"
+current = "0.2.0"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
Fixes #251. The issue stems from the fact that users may interpolate to points far outside the domain of the existing solutions. Linear extrapolation is really bad in this context so we now use a hybrid approach - linear interpolation in the domain and nearest neighbour interpolation/extrapolation outside the domain. This should be approximately safe. 

A few more experiments are required to validate the new behaviour in the presence of heavily flagged data. 