### PR TITLE
Don't allow restore app to overwrite metadata

### DIFF
--- a/quartical/apps/backup.py
+++ b/quartical/apps/backup.py
@@ -140,7 +140,7 @@ def restore():
                                       index_cols=("TIME",),
                                       group_cols=("FIELD_ID", "DATA_DESC_ID", "SCAN_NUMBER"),)
 
-    for i, (ds, dsr) in enumerate(ms_xds_list, zarr_xds_list):
+    for i, (ds, dsr) in enumerate(zip(ms_xds_list, zarr_xds_list)):
         data_array = getattr(dsr, args.column_name)
         ms_xds_list[i] = ds.assign(**{
             args.column_name : (data_array.dims, data_array.data)

--- a/quartical/apps/backup.py
+++ b/quartical/apps/backup.py
@@ -136,8 +136,18 @@ def restore():
 
     zarr_xds_list = xds_from_zarr(f"{zarr_root}::{zarr_name}")
 
+    ms_xds_list = xds_from_storage_ms(args.ms_path,
+                                      index_cols=("TIME",),
+                                      group_cols=("FIELD_ID", "DATA_DESC_ID", "SCAN_NUMBER"),)
+
+    for i, (ds, dsr) in enumerate(ms_xds_list, zarr_xds_list):
+        data_array = getattr(dsr, args.column_name)
+        ms_xds_list[i] = ds.assign(**{
+            args.column_name : (data_array.dims, data_array.data)
+        })
+
     restored_xds_list = xds_to_storage_table(
-        zarr_xds_list,
+        ms_xds_list,
         args.ms_path,
         columns=(args.column_name,),
         rechunk=True

--- a/quartical/apps/backup.py
+++ b/quartical/apps/backup.py
@@ -136,14 +136,19 @@ def restore():
 
     zarr_xds_list = xds_from_zarr(f"{zarr_root}::{zarr_name}")
 
+    # this will fail if the column does not exist but if we allow all columns
+    # we need to select out the relevant dims for rechunking below
     ms_xds_list = xds_from_storage_ms(args.ms_path,
+                                      columns=(args.column_name,),
                                       index_cols=("TIME",),
                                       group_cols=("FIELD_ID", "DATA_DESC_ID", "SCAN_NUMBER"),)
 
     for i, (ds, dsr) in enumerate(zip(ms_xds_list, zarr_xds_list)):
+        dsr = dsr.chunk(ds.chunks)
         data_array = getattr(dsr, args.column_name)
         ms_xds_list[i] = ds.assign(**{
-            args.column_name : (data_array.dims, data_array.data)
+            args.column_name : (data_array.dims,
+                                data_array.data)
         })
 
     restored_xds_list = xds_to_storage_table(

--- a/quartical/apps/backup.py
+++ b/quartical/apps/backup.py
@@ -137,20 +137,21 @@ def restore():
     zarr_xds_list = xds_from_zarr(f"{zarr_root}::{zarr_name}")
     backup_column_name = list(zarr_xds_list[0].data_vars.keys()).pop()
 
-    # this will fail if the column does not exist but if we allow all columns
+    # This will fail if the column does not exist but if we allow all columns
     # we need to select out the relevant dims for rechunking below
-    ms_xds_list = xds_from_storage_ms(args.ms_path,
-                                      columns=(args.column_name,),
-                                      index_cols=("TIME",),
-                                      group_cols=("FIELD_ID", "DATA_DESC_ID", "SCAN_NUMBER"),)
+    ms_xds_list = xds_from_storage_ms(
+        args.ms_path,
+        columns=(args.column_name,),
+        index_cols=("TIME",),
+        group_cols=("FIELD_ID", "DATA_DESC_ID", "SCAN_NUMBER"),
+    )
 
     for i, (ds, dsr) in enumerate(zip(ms_xds_list, zarr_xds_list)):
         dsr = dsr.chunk(ds.chunks)
         data_array = getattr(dsr, backup_column_name)
-        ms_xds_list[i] = ds.assign(**{
-            args.column_name : (data_array.dims,
-                                data_array.data)
-        })
+        ms_xds_list[i] = ds.assign(
+            {args.column_name: (data_array.dims, data_array.data)}
+        )
 
     restored_xds_list = xds_to_storage_table(
         ms_xds_list,

--- a/quartical/apps/backup.py
+++ b/quartical/apps/backup.py
@@ -135,6 +135,7 @@ def restore():
     zarr_root, zarr_name = args.zarr_path.url.rsplit("/", 1)
 
     zarr_xds_list = xds_from_zarr(f"{zarr_root}::{zarr_name}")
+    backup_column_name = list(zarr_xds_list[0].data_vars.keys()).pop()
 
     # this will fail if the column does not exist but if we allow all columns
     # we need to select out the relevant dims for rechunking below
@@ -145,7 +146,7 @@ def restore():
 
     for i, (ds, dsr) in enumerate(zip(ms_xds_list, zarr_xds_list)):
         dsr = dsr.chunk(ds.chunks)
-        data_array = getattr(dsr, args.column_name)
+        data_array = getattr(dsr, backup_column_name)
         ms_xds_list[i] = ds.assign(**{
             args.column_name : (data_array.dims,
                                 data_array.data)


### PR DESCRIPTION
This is a partial fix for https://github.com/ratt-ru/QuartiCal/issues/297. The remaining cases that are not catered for are:

* restoring to a non-existent column (i.e. create a new column)
* I believe there may also still be an issue when trying to restore to a non-standard column in an MS as it needs a a schema.

I believe these are both fairly exotic use cases but let me know if you want me to look into that @JSKenyon 