### PR TITLE
Fix xarray dims

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quartical"
-version = "0.1.11"
+version = "0.2.0"
 description = "Fast and flexible calibration suite for radio interferometer data."
 repository = "https://github.com/ratt-ru/QuartiCal"
 documentation = "https://quartical.readthedocs.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quartical"
-version = "0.1.10"
+version = "0.1.11"
 description = "Fast and flexible calibration suite for radio interferometer data."
 repository = "https://github.com/ratt-ru/QuartiCal"
 documentation = "https://quartical.readthedocs.io"

--- a/quartical/apps/summary.py
+++ b/quartical/apps/summary.py
@@ -116,7 +116,7 @@ def field_info(path):
 
     field_xds = xds_from_storage_table(path + "::FIELD")[0]
 
-    field_ids = list(range(field_xds.dims['row']))
+    field_ids = list(range(field_xds.sizes['row']))
     source_ids = [i for i in field_xds.SOURCE_ID.values]
     names = [n for n in field_xds.NAME.values]
     phase_dirs = [pd for pd in field_xds.PHASE_DIR.values]
@@ -196,7 +196,7 @@ def spw_info(path):
         chunks={"row": 1, "chan": -1}
     )
 
-    n_chan_per_spw = [xds.dims["chan"] for xds in spw_xds_list]
+    n_chan_per_spw = [xds.sizes["chan"] for xds in spw_xds_list]
 
     bw_per_spw = [xds.TOTAL_BANDWIDTH.values.item() for xds in spw_xds_list]
 
@@ -241,9 +241,9 @@ def pointing_info(path):
 
 def dimension_summary(xds_list):
 
-    rows_per_xds = [xds.dims["row"] for xds in xds_list]
-    chan_per_xds = [xds.dims["chan"] for xds in xds_list]
-    corr_per_xds = [xds.dims["corr"] for xds in xds_list]
+    rows_per_xds = [xds.sizes["row"] for xds in xds_list]
+    chan_per_xds = [xds.sizes["chan"] for xds in xds_list]
+    corr_per_xds = [xds.sizes["corr"] for xds in xds_list]
 
     utime_per_xds = [np.unique(xds.TIME.values).size for xds in xds_list]
 

--- a/quartical/calibration/calibrate.py
+++ b/quartical/calibration/calibrate.py
@@ -134,7 +134,7 @@ def add_calibration_graph(
     """
 
     # TODO: Does this check belong here or elsewhere?
-    have_dd_model = any(xds.dims['dir'] > 1 for xds in data_xds_list)
+    have_dd_model = any(xds.sizes['dir'] > 1 for xds in data_xds_list)
     have_dd_chain = any(term.direction_dependent for term in chain)
 
     if have_dd_model and not have_dd_chain:
@@ -254,7 +254,7 @@ def make_visibility_output(
     itr = enumerate(zip(data_xds_list, mapping_xds_list))
 
     if output_opts.subtract_directions:
-        n_dir = data_xds_list[0].dims['dir']  # Should be the same on all xdss.
+        n_dir = data_xds_list[0].sizes['dir']  # Should be the same over xdss.
         requested = set(output_opts.subtract_directions)
         valid = set(range(n_dir))
         invalid = requested - valid
@@ -283,7 +283,7 @@ def make_visibility_output(
             [mapping_xds.get(f"{k}_dir_map").data for k in gain_terms.keys()]
         )
 
-        corr_mode = data_xds.dims["corr"]
+        corr_mode = data_xds.sizes["corr"]
 
         is_bda = hasattr(data_xds, "ROW_MAP")  # We are dealing with BDA.
         row_map = data_xds.ROW_MAP.data if is_bda else None

--- a/quartical/calibration/constructor.py
+++ b/quartical/calibration/constructor.py
@@ -51,7 +51,7 @@ def construct_solver(
         weight_col = data_xds.WEIGHT.data
         flag_col = data_xds.FLAG.data
         gain_terms = gain_xds_lod[xds_ind]
-        corr_mode = data_xds.dims["corr"]
+        corr_mode = data_xds.sizes["corr"]
 
         block_id_arr = get_block_id_arr(data_col)
         aux_block_info = {
@@ -77,7 +77,7 @@ def construct_solver(
             blocker.add_input(
                 v.name,
                 v.data,
-                ("row",) if v.dims == ("time",) else v.dims
+                ("row",) if set(v.dims) == {"time"} else v.dims
             )
 
         blocker.add_input(
@@ -272,8 +272,8 @@ def expand_specs(gain_terms):
     # represents frequency chunks and the inner-most list contains the
     # specs per term. Might be possible to do this with arrays instead.
 
-    n_t_chunks = set(xds.dims["time_chunk"] for xds in gain_terms.values())
-    n_f_chunks = set(xds.dims["freq_chunk"] for xds in gain_terms.values())
+    n_t_chunks = set(xds.sizes["time_chunk"] for xds in gain_terms.values())
+    n_f_chunks = set(xds.sizes["freq_chunk"] for xds in gain_terms.values())
 
     assert len(n_t_chunks) == 1, "Chunking in time is inconsistent."
     assert len(n_f_chunks) == 1, "Chunking in freq is inconsistent."

--- a/quartical/calibration/mapping.py
+++ b/quartical/calibration/mapping.py
@@ -63,7 +63,7 @@ def make_mapping_datasets(data_xds_list, chain):
                 freq_interval
             )
 
-            n_dir = data_xds.dims["dir"]
+            n_dir = data_xds.sizes["dir"]
 
             dir_map = gain_obj.make_dir_map(
                 n_dir,

--- a/quartical/data_handling/angles.py
+++ b/quartical/data_handling/angles.py
@@ -75,7 +75,7 @@ def make_parangle_xds_list(ms_path, data_xds_list):
             coords={
                 "utime": np.arange(sum(xds.UTIME_CHUNKS)),
                 "ant": xds.ant,
-                "receptor": np.arange(feedtab.dims['receptors'])
+                "receptor": np.arange(feedtab.sizes['receptors'])
             },
             attrs={
                 "FEED_TYPE": feed_type,

--- a/quartical/data_handling/bda.py
+++ b/quartical/data_handling/bda.py
@@ -64,7 +64,7 @@ def process_bda_input(data_xds_list, spw_xds_list, weight_column):
                          "WEIGHT_SPECTRUM for BDA data.")
 
     # Figure out the highest frequency resolution and its DDID.
-    spw_dims = {i: xds.dims["chan"] for i, xds in enumerate(spw_xds_list)}
+    spw_dims = {i: xds.sizes["chan"] for i, xds in enumerate(spw_xds_list)}
     max_nchan_ddid = max(spw_dims, key=spw_dims.get)
     max_nchan = spw_dims[max_nchan_ddid]
 
@@ -72,7 +72,7 @@ def process_bda_input(data_xds_list, spw_xds_list, weight_column):
 
     for xds in data_xds_list:
 
-        upsample_factor = max_nchan//xds.dims["chan"]
+        upsample_factor = max_nchan//xds.sizes["chan"]
 
         weight_col = xds.WEIGHT_SPECTRUM.data
 
@@ -83,7 +83,7 @@ def process_bda_input(data_xds_list, spw_xds_list, weight_column):
                                  weight_col/upsample_factor)})
 
         # Create a selection which will upsample the frequency axis.
-        selection = np.repeat(np.arange(xds.dims["chan"]), upsample_factor)
+        selection = np.repeat(np.arange(xds.sizes["chan"]), upsample_factor)
 
         bda_xds = bda_xds.sel({"chan": selection})
 
@@ -101,7 +101,7 @@ def process_bda_input(data_xds_list, spw_xds_list, weight_column):
     bda_xds_list = [xarray.concat(xdss, dim="row")
                     for xdss in xds_merge_list]
 
-    bda_xds_list = [xds.chunk({"row": xds.dims["row"]})
+    bda_xds_list = [xds.chunk({"row": xds.sizes["row"]})
                     for xds in bda_xds_list]
 
     # This should guarantee monotonicity in time (not baseline).
@@ -223,10 +223,10 @@ def process_bda_output(xds_list, ref_xds_list, output_cols):
 
                 chan_ind = dims.index('chan')
 
-                nchan = xds.dims['chan']
-                ref_nchan = ref_xds.dims['chan']
+                nchan = xds.sizes['chan']
+                ref_nchan = ref_xds.sizes['chan']
 
-                shape[chan_ind: chan_ind + 1] = [ref_xds.dims['chan'], -1]
+                shape[chan_ind: chan_ind + 1] = [ref_xds.sizes['chan'], -1]
 
                 data = data.reshape(shape)
 

--- a/quartical/data_handling/model_handler.py
+++ b/quartical/data_handling/model_handler.py
@@ -56,7 +56,7 @@ def add_model_graph(
     # which require them. P Jones is applied to predicted components
     # internally, so we only need to consider model columns for now.
 
-    n_corr = {xds.dims["corr"] for xds in data_xds_list}.pop()
+    n_corr = {xds.sizes["corr"] for xds in data_xds_list}.pop()
 
     if model_opts.apply_p_jones:
         # NOTE: Applying parallactic angle when there are fewer than four
@@ -183,9 +183,9 @@ def assign_identity_model(data_xds_list):
 
     model_dims = [
         (
-            xds.dims['row'],
-            xds.dims['chan'],
-            xds.dims['corr']
+            xds.sizes['row'],
+            xds.sizes['chan'],
+            xds.sizes['corr']
         )
         for xds in data_xds_list
     ]

--- a/quartical/data_handling/ms_handler.py
+++ b/quartical/data_handling/ms_handler.py
@@ -30,7 +30,7 @@ def read_xds_list(model_columns, ms_opts):
 
     antenna_xds = xds_from_storage_table(ms_opts.path + "::ANTENNA")[0]
 
-    n_ant = antenna_xds.dims["row"]
+    n_ant = antenna_xds.sizes["row"]
 
     logger.info("Antenna table indicates {} antennas were present for this "
                 "observation.", n_ant)
@@ -139,7 +139,7 @@ def read_xds_list(model_columns, ms_opts):
     for xds_ind, xds in enumerate(data_xds_list):
         # Add coordinates to the xarray datasets.
         _xds = xds.assign_coords({"corr": corr_types,
-                                  "chan": np.arange(xds.dims["chan"]),
+                                  "chan": np.arange(xds.sizes["chan"]),
                                   "ant": ant_names})
 
         # Add the actual channel frequecies to the xds - this is in preparation
@@ -236,7 +236,7 @@ def write_xds_list(xds_list, ref_xds_list, ms_path, output_opts):
             xds = xds.isel(corr=u_corr_ind)
 
         # If the xds has fewer correlations than the measurement set, reindex.
-        if xds.dims["corr"] < ms_n_corr:
+        if xds.sizes["corr"] < ms_n_corr:
             xds = xds.reindex(corr=corr_types, fill_value=0)
 
             # Do some special handling on the flag column if we reindexed -
@@ -409,7 +409,7 @@ def postprocess_xds_list(data_xds_list, parangle_xds_list, output_opts):
             data with postprocessing operations applied.
     """
 
-    n_corr = {xds.dims["corr"] for xds in data_xds_list}.pop()
+    n_corr = {xds.sizes["corr"] for xds in data_xds_list}.pop()
 
     if output_opts.apply_p_jones_inv:
         # NOTE: Applying parallactic angle when there are fewer than four

--- a/quartical/flagging/flagging.py
+++ b/quartical/flagging/flagging.py
@@ -145,7 +145,7 @@ def add_mad_graph(data_xds_list, mad_opts):
         flag_col = xds.FLAG.data
         ant1_col = xds.ANTENNA1.data
         ant2_col = xds.ANTENNA2.data
-        n_ant = xds.dims["ant"]
+        n_ant = xds.sizes["ant"]
         n_bl_w_autos = (n_ant * (n_ant - 1))/2 + n_ant
         n_t_chunk, n_f_chunk, _ = residuals.numblocks
 

--- a/quartical/gains/baseline.py
+++ b/quartical/gains/baseline.py
@@ -37,7 +37,7 @@ def compute_baseline_corrections(
         weight_col = data_xds._WEIGHT.data  # The weights exiting the solver.
         ant1_col = data_xds.ANTENNA1.data
         ant2_col = data_xds.ANTENNA2.data
-        corr_mode = data_xds.dims["corr"]
+        corr_mode = data_xds.sizes["corr"]
 
         time_maps = tuple(
             [mapping_xds.get(f"{k}_time_map").data for k in gain_dict.keys()]
@@ -63,7 +63,7 @@ def compute_baseline_corrections(
             req_args.extend([fm, ("gain_freq",)])
             req_args.extend([dm, ("direction",)])
 
-        n_ant = data_xds.dims["ant"]
+        n_ant = data_xds.sizes["ant"]
         n_bla = int((n_ant*(n_ant - 1))/2 + n_ant)
 
         bl_corr = da.blockwise(

--- a/quartical/gains/datasets.py
+++ b/quartical/gains/datasets.py
@@ -192,7 +192,7 @@ def populate_net_xds_list(
 
             net_xds = net_gains[net_name]
 
-            net_shape = tuple(net_xds.dims[d] for d in net_xds.GAIN_AXES)
+            net_shape = tuple(net_xds.sizes[d] for d in net_xds.GAIN_AXES)
 
             corr_mode = net_shape[-1]
 
@@ -401,7 +401,7 @@ def scaffold_from_data_xds(data_xds, gain_obj):
 
     freq_chunks = gain_obj.make_freq_chunks(freq_map)
 
-    n_dir = data_xds.dims["dir"]
+    n_dir = data_xds.sizes["dir"]
 
     dir_map = gain_obj.make_dir_map(
         n_dir,
@@ -418,8 +418,8 @@ def scaffold_from_data_xds(data_xds, gain_obj):
     id_attrs = {f: data_xds.attrs[f] for f, _ in partition_schema}
 
     # TODO: Move this the the gain object?
-    n_corr = data_xds.dims["corr"]
-    n_ant = data_xds.dims["ant"]
+    n_corr = data_xds.sizes["corr"]
+    n_ant = data_xds.sizes["ant"]
     chunk_spec = gain_spec_tup(
         time_chunks,
         freq_chunks,

--- a/quartical/interpolation/interpolants.py
+++ b/quartical/interpolation/interpolants.py
@@ -25,8 +25,8 @@ def linear2d_interpolate_gains(source_xds, target_xds):
         i_t_axis, i_f_axis = source_xds.GAIN_AXES[:2]
         t_t_axis, t_f_axis = target_xds.GAIN_AXES[:2]
 
-    i_t_dim = source_xds.dims[i_t_axis]
-    i_f_dim = source_xds.dims[i_f_axis]
+    i_t_dim = source_xds.sizes[i_t_axis]
+    i_f_dim = source_xds.sizes[i_f_axis]
 
     interp_axes = {}
 
@@ -124,12 +124,12 @@ def spline2d_interpolate_gains(source_xds, target_xds):
         i_t_axis, i_f_axis = source_xds.GAIN_AXES[:2]
         t_t_axis, t_f_axis = target_xds.GAIN_AXES[:2]
 
-    if source_xds.dims[i_t_axis] < 4 or source_xds.dims[i_f_axis] < 4:
+    if source_xds.sizes[i_t_axis] < 4 or source_xds.sizes[i_f_axis] < 4:
         raise ValueError(
             f"Cubic spline interpolation requires at least four "
             f"values along an axis. After concatenation, the "
             f"(time, freq) dimensions of the interpolating dataset were "
-            f"{(source_xds.dims[i_t_axis], source_xds.dims[i_f_axis])}."
+            f"{(source_xds.sizes[i_t_axis], source_xds.sizes[i_f_axis])}."
         )
 
     interp_arr = da.blockwise(
@@ -141,8 +141,8 @@ def spline2d_interpolate_gains(source_xds, target_xds):
         target_xds[t_f_axis].values, None,
         dtype=np.float64,
         adjust_chunks={
-            "t": target_xds.dims[t_t_axis],
-            "f": target_xds.dims[t_f_axis]
+            "t": target_xds.sizes[t_t_axis],
+            "f": target_xds.sizes[t_f_axis]
         }
     )
 

--- a/quartical/interpolation/interpolate.py
+++ b/quartical/interpolation/interpolate.py
@@ -90,7 +90,7 @@ def load_and_interpolate_gains(gain_xds_lod, chain, output_directory):
             )
 
         # Remove time/chan chunking and rechunk by antenna.
-        merged_xds = merged_xds.chunk({**merged_xds.dims, "antenna": 1})
+        merged_xds = merged_xds.chunk({**merged_xds.sizes, "antenna": 1})
 
         # Create a converter object to handle moving between native and
         # interpolation representations.
@@ -221,11 +221,11 @@ def reindex_and_rechunk(interpolated_xds, reference_xds):
 
     # If we are loading a term with a differing number of correlations,
     # this should handle selecting them out/padding them in.
-    if interpolated_xds.dims[axis] < reference_xds.dims[axis]:
+    if interpolated_xds.sizes[axis] < reference_xds.sizes[axis]:
         interpolated_xds = interpolated_xds.reindex(
             {"correlation": reference_xds[axis]}, fill_value=0
         )
-    elif interpolated_xds.dims[axis] > reference_xds.dims[axis]:
+    elif interpolated_xds.sizes[axis] > reference_xds.sizes[axis]:
         interpolated_xds = interpolated_xds.sel(
             {"correlation": reference_xds[axis]}
         )
@@ -240,7 +240,7 @@ def reindex_and_rechunk(interpolated_xds, reference_xds):
         {
             t_t_axis: t_chunks,
             t_f_axis: f_chunks,
-            "antenna": interpolated_xds.dims["antenna"]
+            "antenna": interpolated_xds.sizes["antenna"]
         }
     )
 

--- a/quartical/statistics/logging.py
+++ b/quartical/statistics/logging.py
@@ -78,8 +78,8 @@ def log_summary_stats(stats_xds_list):
 
     for sxds_group in sxds_groups:
 
-        max_nt_chunk = max([sxds.dims["t_chunk"] for sxds in sxds_group])
-        max_nf_chunk = max([sxds.dims["f_chunk"] for sxds in sxds_group])
+        max_nt_chunk = max([sxds.sizes["t_chunk"] for sxds in sxds_group])
+        max_nf_chunk = max([sxds.sizes["f_chunk"] for sxds in sxds_group])
 
         ids = [f"T{t}F{f}" for t in range(max_nt_chunk)
                            for f in range(max_nf_chunk)]  # noqa

--- a/tbump.toml
+++ b/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/ratt-ru/QuartiCal/"
 
 [version]
-current = "0.1.11"
+current = "0.2.0"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before

--- a/testing/tests/calibration/test_calibrate.py
+++ b/testing/tests/calibration/test_calibrate.py
@@ -24,7 +24,7 @@ def opts(base_opts, time_chunk, freq_chunk, time_int, freq_int):
 @pytest.fixture(scope="module")
 def expected_t_ints(single_xds, chain):
 
-    n_row = single_xds.dims["row"]
+    n_row = single_xds.sizes["row"]
     t_ints = [term.time_interval or n_row for term in chain]
 
     expected_t_ints = []
@@ -62,7 +62,7 @@ def expected_t_ints(single_xds, chain):
 @pytest.fixture(scope="module")
 def expected_f_ints(single_xds, chain):
 
-    n_chan = single_xds.dims["chan"]
+    n_chan = single_xds.sizes["chan"]
     f_ints = [term.freq_interval or n_chan for term in chain]
 
     expected_f_ints = []
@@ -109,7 +109,7 @@ def test_data_coords(single_xds, term_xds_dict):
     data_coords = ["ant", "dir", "corr"]
     gain_coords = ["antenna", "direction", "correlation"]
 
-    assert all(single_xds.dims[dc] == gxds.dims[gc]
+    assert all(single_xds.sizes[dc] == gxds.sizes[gc]
                for gxds in term_xds_dict.values()
                for dc, gc in zip(data_coords, gain_coords))
 
@@ -118,7 +118,7 @@ def test_data_coords(single_xds, term_xds_dict):
 def test_t_chunking(single_xds, term_xds_dict):
     """Check that time chunking of the gain xds list is correct."""
 
-    assert all(len(single_xds.UTIME_CHUNKS) == gxds.dims["time_chunk"]
+    assert all(len(single_xds.UTIME_CHUNKS) == gxds.sizes["time_chunk"]
                for gxds in term_xds_dict.values())
 
 
@@ -126,7 +126,7 @@ def test_t_chunking(single_xds, term_xds_dict):
 def test_f_chunking(single_xds, term_xds_dict):
     """Check that frequency chunking of the gain xds list is correct."""
 
-    assert all(len(single_xds.chunks["chan"]) == gxds.dims["freq_chunk"]
+    assert all(len(single_xds.chunks["chan"]) == gxds.sizes["freq_chunk"]
                for gxds in term_xds_dict.values())
 
 
@@ -134,7 +134,7 @@ def test_f_chunking(single_xds, term_xds_dict):
 def test_t_ints(term_xds_dict, expected_t_ints):
     """Check that the time intervals are correct."""
 
-    assert all(int(sum(eti)) == gxds.dims["gain_time"]
+    assert all(int(sum(eti)) == gxds.sizes["gain_time"]
                for eti, gxds in zip(expected_t_ints, term_xds_dict.values()))
 
 
@@ -142,7 +142,7 @@ def test_t_ints(term_xds_dict, expected_t_ints):
 def test_f_ints(term_xds_dict, expected_f_ints):
     """Check that the frequency intervals are correct."""
 
-    assert all(int(sum(efi)) == gxds.dims["gain_freq"]
+    assert all(int(sum(efi)) == gxds.sizes["gain_freq"]
                for efi, gxds in zip(expected_f_ints, term_xds_dict.values()))
 
 
@@ -163,7 +163,7 @@ def test_chunk_spec(single_xds, term_xds_dict, expected_t_ints,
     """Check that the chunking specs are correct."""
 
     n_row, n_chan, n_ant, n_dir, n_corr = \
-        [single_xds.dims[d] for d in ["row", "chan", "ant", "dir", "corr"]]
+        [single_xds.sizes[d] for d in ["row", "chan", "ant", "dir", "corr"]]
 
     specs = [tuple([tuple(tic), tuple(fic), (n_ant,), (n_dir,), (n_corr,)])
              for tic, fic in zip(expected_t_ints, expected_f_ints)]

--- a/testing/tests/gains/test_amplitude.py
+++ b/testing/tests/gains/test_amplitude.py
@@ -39,13 +39,13 @@ def true_gain_list(predicted_xds_list, solve_per):
 
     for xds in predicted_xds_list:
 
-        n_ant = xds.dims["ant"]
+        n_ant = xds.sizes["ant"]
         utime_chunks = xds.UTIME_CHUNKS
         n_time = sum(utime_chunks)
         chan_chunks = xds.chunks["chan"]
-        n_chan = xds.dims["chan"]
-        n_dir = xds.dims["dir"]
-        n_corr = xds.dims["corr"]
+        n_chan = xds.sizes["chan"]
+        n_dir = xds.sizes["dir"]
+        n_corr = xds.sizes["corr"]
 
         chunking = (utime_chunks, chan_chunks, n_ant, n_dir, n_corr)
 
@@ -81,7 +81,7 @@ def corrupted_data_xds_list(predicted_xds_list, true_gain_list):
 
     for xds, gains in zip(predicted_xds_list, true_gain_list):
 
-        n_corr = xds.dims["corr"]
+        n_corr = xds.sizes["corr"]
 
         ant1 = xds.ANTENNA1.data
         ant2 = xds.ANTENNA2.data

--- a/testing/tests/gains/test_complex.py
+++ b/testing/tests/gains/test_complex.py
@@ -39,13 +39,13 @@ def true_gain_list(predicted_xds_list, solve_per):
 
     for xds in predicted_xds_list:
 
-        n_ant = xds.dims["ant"]
+        n_ant = xds.sizes["ant"]
         utime_chunks = xds.UTIME_CHUNKS
         n_time = sum(utime_chunks)
         chan_chunks = xds.chunks["chan"]
-        n_chan = xds.dims["chan"]
-        n_dir = xds.dims["dir"]
-        n_corr = xds.dims["corr"]
+        n_chan = xds.sizes["chan"]
+        n_dir = xds.sizes["dir"]
+        n_corr = xds.sizes["corr"]
 
         chunking = (utime_chunks, chan_chunks, n_ant, n_dir, n_corr)
 
@@ -79,7 +79,7 @@ def corrupted_data_xds_list(predicted_xds_list, true_gain_list):
 
     for xds, gains in zip(predicted_xds_list, true_gain_list):
 
-        n_corr = xds.dims["corr"]
+        n_corr = xds.sizes["corr"]
 
         ant1 = xds.ANTENNA1.data
         ant2 = xds.ANTENNA2.data

--- a/testing/tests/gains/test_crosshand_phase.py
+++ b/testing/tests/gains/test_crosshand_phase.py
@@ -40,13 +40,13 @@ def true_gain_list(predicted_xds_list):
 
     for xds in predicted_xds_list:
 
-        n_ant = xds.dims["ant"]
+        n_ant = xds.sizes["ant"]
         utime_chunks = xds.UTIME_CHUNKS
         n_time = sum(utime_chunks)
         chan_chunks = xds.chunks["chan"]
-        n_chan = xds.dims["chan"]
-        n_dir = xds.dims["dir"]
-        n_corr = xds.dims["corr"]
+        n_chan = xds.sizes["chan"]
+        n_dir = xds.sizes["dir"]
+        n_corr = xds.sizes["corr"]
 
         chunking = (len(utime_chunks), chan_chunks, n_ant, n_dir, n_corr)
 
@@ -78,7 +78,7 @@ def corrupted_data_xds_list(predicted_xds_list, true_gain_list):
 
     for xds, gains in zip(predicted_xds_list, true_gain_list):
 
-        n_corr = xds.dims["corr"]
+        n_corr = xds.sizes["corr"]
 
         ant1 = xds.ANTENNA1.data
         ant2 = xds.ANTENNA2.data

--- a/testing/tests/gains/test_delay.py
+++ b/testing/tests/gains/test_delay.py
@@ -40,13 +40,13 @@ def true_gain_list(predicted_xds_list):
 
     for xds in predicted_xds_list:
 
-        n_ant = xds.dims["ant"]
+        n_ant = xds.sizes["ant"]
         utime_chunks = xds.UTIME_CHUNKS
         n_time = sum(utime_chunks)
         chan_chunks = xds.chunks["chan"]
-        n_chan = xds.dims["chan"]
-        n_dir = xds.dims["dir"]
-        n_corr = xds.dims["corr"]
+        n_chan = xds.sizes["chan"]
+        n_dir = xds.sizes["dir"]
+        n_corr = xds.sizes["corr"]
 
         chan_freq = xds.CHAN_FREQ.data
         chan_width = chan_freq[1] - chan_freq[0]
@@ -86,7 +86,7 @@ def corrupted_data_xds_list(predicted_xds_list, true_gain_list):
 
     for xds, gains in zip(predicted_xds_list, true_gain_list):
 
-        n_corr = xds.dims["corr"]
+        n_corr = xds.sizes["corr"]
 
         ant1 = xds.ANTENNA1.data
         ant2 = xds.ANTENNA2.data

--- a/testing/tests/gains/test_delay_and_offset.py
+++ b/testing/tests/gains/test_delay_and_offset.py
@@ -40,13 +40,13 @@ def true_gain_list(predicted_xds_list):
 
     for xds in predicted_xds_list:
 
-        n_ant = xds.dims["ant"]
+        n_ant = xds.sizes["ant"]
         utime_chunks = xds.UTIME_CHUNKS
         n_time = sum(utime_chunks)
         chan_chunks = xds.chunks["chan"]
-        n_chan = xds.dims["chan"]
-        n_dir = xds.dims["dir"]
-        n_corr = xds.dims["corr"]
+        n_chan = xds.sizes["chan"]
+        n_dir = xds.sizes["dir"]
+        n_corr = xds.sizes["corr"]
 
         chan_freq = xds.CHAN_FREQ.data
         chan_width = chan_freq[1] - chan_freq[0]
@@ -94,7 +94,7 @@ def corrupted_data_xds_list(predicted_xds_list, true_gain_list):
 
     for xds, gains in zip(predicted_xds_list, true_gain_list):
 
-        n_corr = xds.dims["corr"]
+        n_corr = xds.sizes["corr"]
 
         ant1 = xds.ANTENNA1.data
         ant2 = xds.ANTENNA2.data

--- a/testing/tests/gains/test_diag_complex.py
+++ b/testing/tests/gains/test_diag_complex.py
@@ -44,13 +44,13 @@ def true_gain_list(predicted_xds_list, solve_per):
 
     for xds in predicted_xds_list:
 
-        n_ant = xds.dims["ant"]
+        n_ant = xds.sizes["ant"]
         utime_chunks = xds.UTIME_CHUNKS
         n_time = sum(utime_chunks)
         chan_chunks = xds.chunks["chan"]
-        n_chan = xds.dims["chan"]
-        n_dir = xds.dims["dir"]
-        n_corr = xds.dims["corr"]
+        n_chan = xds.sizes["chan"]
+        n_dir = xds.sizes["dir"]
+        n_corr = xds.sizes["corr"]
 
         chunking = (utime_chunks, chan_chunks, n_ant, n_dir, n_corr)
 
@@ -84,7 +84,7 @@ def corrupted_data_xds_list(predicted_xds_list, true_gain_list):
 
     for xds, gains in zip(predicted_xds_list, true_gain_list):
 
-        n_corr = xds.dims["corr"]
+        n_corr = xds.sizes["corr"]
 
         ant1 = xds.ANTENNA1.data
         ant2 = xds.ANTENNA2.data

--- a/testing/tests/gains/test_phase.py
+++ b/testing/tests/gains/test_phase.py
@@ -39,13 +39,13 @@ def true_gain_list(predicted_xds_list, solve_per):
 
     for xds in predicted_xds_list:
 
-        n_ant = xds.dims["ant"]
+        n_ant = xds.sizes["ant"]
         utime_chunks = xds.UTIME_CHUNKS
         n_time = sum(utime_chunks)
         chan_chunks = xds.chunks["chan"]
-        n_chan = xds.dims["chan"]
-        n_dir = xds.dims["dir"]
-        n_corr = xds.dims["corr"]
+        n_chan = xds.sizes["chan"]
+        n_dir = xds.sizes["dir"]
+        n_corr = xds.sizes["corr"]
 
         chunking = (utime_chunks, chan_chunks, n_ant, n_dir, n_corr)
 
@@ -79,7 +79,7 @@ def corrupted_data_xds_list(predicted_xds_list, true_gain_list):
 
     for xds, gains in zip(predicted_xds_list, true_gain_list):
 
-        n_corr = xds.dims["corr"]
+        n_corr = xds.sizes["corr"]
 
         ant1 = xds.ANTENNA1.data
         ant2 = xds.ANTENNA2.data

--- a/testing/tests/gains/test_rotation.py
+++ b/testing/tests/gains/test_rotation.py
@@ -38,13 +38,13 @@ def true_gain_list(predicted_xds_list, solve_per):
 
     for xds in predicted_xds_list:
 
-        n_ant = xds.dims["ant"]
+        n_ant = xds.sizes["ant"]
         utime_chunks = xds.UTIME_CHUNKS
         n_time = sum(utime_chunks)
         chan_chunks = xds.chunks["chan"]
-        n_chan = xds.dims["chan"]
-        n_dir = xds.dims["dir"]
-        n_corr = xds.dims["corr"]
+        n_chan = xds.sizes["chan"]
+        n_dir = xds.sizes["dir"]
+        n_corr = xds.sizes["corr"]
 
         chunking = (utime_chunks, chan_chunks, n_ant, n_dir, n_corr)
 
@@ -75,7 +75,7 @@ def corrupted_data_xds_list(predicted_xds_list, true_gain_list):
 
     for xds, gains in zip(predicted_xds_list, true_gain_list):
 
-        n_corr = xds.dims["corr"]
+        n_corr = xds.sizes["corr"]
 
         ant1 = xds.ANTENNA1.data
         ant2 = xds.ANTENNA2.data

--- a/testing/tests/gains/test_rotation_measure.py
+++ b/testing/tests/gains/test_rotation_measure.py
@@ -40,13 +40,13 @@ def true_gain_list(predicted_xds_list, solve_per):
 
     for xds in predicted_xds_list:
 
-        n_ant = xds.dims["ant"]
+        n_ant = xds.sizes["ant"]
         utime_chunks = xds.UTIME_CHUNKS
         n_time = sum(utime_chunks)
         chan_chunks = xds.chunks["chan"]
-        n_chan = xds.dims["chan"]
-        n_dir = xds.dims["dir"]
-        n_corr = xds.dims["corr"]
+        n_chan = xds.sizes["chan"]
+        n_dir = xds.sizes["dir"]
+        n_corr = xds.sizes["corr"]
 
         lambda_sq = (299792458/xds.CHAN_FREQ.data)**2
 
@@ -82,7 +82,7 @@ def corrupted_data_xds_list(predicted_xds_list, true_gain_list):
 
     for xds, gains in zip(predicted_xds_list, true_gain_list):
 
-        n_corr = xds.dims["corr"]
+        n_corr = xds.sizes["corr"]
 
         ant1 = xds.ANTENNA1.data
         ant2 = xds.ANTENNA2.data

--- a/testing/tests/gains/test_tec_and_offset.py
+++ b/testing/tests/gains/test_tec_and_offset.py
@@ -39,13 +39,13 @@ def true_gain_list(predicted_xds_list):
 
     for xds in predicted_xds_list:
 
-        n_ant = xds.dims["ant"]
+        n_ant = xds.sizes["ant"]
         utime_chunks = xds.UTIME_CHUNKS
         n_time = sum(utime_chunks)
         chan_chunks = xds.chunks["chan"]
-        n_chan = xds.dims["chan"]
-        n_dir = xds.dims["dir"]
-        n_corr = xds.dims["corr"]
+        n_chan = xds.sizes["chan"]
+        n_dir = xds.sizes["dir"]
+        n_corr = xds.sizes["corr"]
 
         chan_freq = xds.CHAN_FREQ.data
         max_tec = 1/(1/chan_freq[-1] - 1/chan_freq[-2])
@@ -96,7 +96,7 @@ def corrupted_data_xds_list(predicted_xds_list, true_gain_list):
 
     for xds, gains in zip(predicted_xds_list, true_gain_list):
 
-        n_corr = xds.dims["corr"]
+        n_corr = xds.sizes["corr"]
 
         ant1 = xds.ANTENNA1.data
         ant2 = xds.ANTENNA2.data


### PR DESCRIPTION
xarray will be changing the return type of `xds.dims` to a set (it is currently a dict). This was generating a huge number of pending deprection warnings. This PR should replace all the required instances of `xds.dims` with `xds.sizes`.