### PR TITLE
Add experimental combined delay and tec solver.

### DIFF
--- a/quartical/config/gain_schema.yaml
+++ b/quartical/config/gain_schema.yaml
@@ -8,6 +8,7 @@ gain:
       - amplitude
       - delay
       - delay_and_offset
+      - delay_and_tec
       - phase
       - tec_and_offset
       - rotation_measure

--- a/quartical/gains/__init__.py
+++ b/quartical/gains/__init__.py
@@ -8,6 +8,7 @@ from quartical.gains.rotation import Rotation
 from quartical.gains.rotation_measure import RotationMeasure
 from quartical.gains.crosshand_phase import CrosshandPhase
 from quartical.gains.leakage import Leakage
+from quartical.gains.delay_and_tec import DelayAndTec
 
 
 TERM_TYPES = {
@@ -21,5 +22,6 @@ TERM_TYPES = {
     "rotation": Rotation,
     "rotation_measure": RotationMeasure,
     "crosshand_phase": CrosshandPhase,
-    "leakage": Leakage
+    "leakage": Leakage,
+    "delay_and_tec": DelayAndTec
 }

--- a/quartical/gains/delay_and_tec/__init__.py
+++ b/quartical/gains/delay_and_tec/__init__.py
@@ -1,0 +1,173 @@
+import numpy as np
+from collections import namedtuple
+from quartical.gains.conversion import no_op, trig_to_angle
+from quartical.gains.parameterized_gain import ParameterizedGain
+from quartical.gains.delay_and_tec.kernel import (
+    delay_and_tec_solver,
+    delay_and_tec_params_to_gains
+)
+from quartical.gains.general.flagging import (
+    apply_gain_flags_to_gains,
+    apply_param_flags_to_params
+)
+
+# Overload the default measurement set inputs to include the frequencies.
+ms_inputs = namedtuple(
+    'ms_inputs', ParameterizedGain.ms_inputs._fields + ('CHAN_FREQ',)
+)
+
+
+class DelayAndTec(ParameterizedGain):
+
+    solver = staticmethod(delay_and_tec_solver)
+    ms_inputs = ms_inputs
+
+    native_to_converted = (
+        (1, (no_op,)),
+        (1, (no_op,))
+    )
+    converted_to_native = (
+        (1, no_op),
+        (1, no_op)
+    )
+    converted_dtype = np.float64
+    native_dtype = np.float64
+
+    def __init__(self, term_name, term_opts):
+
+        super().__init__(term_name, term_opts)
+
+    @classmethod
+    def _make_freq_map(cls, chan_freqs, chan_widths, freq_interval):
+        # Overload gain mapping construction - we evaluate it in every channel.
+        return np.arange(chan_freqs.size, dtype=np.int32)
+
+    @classmethod
+    def make_param_names(cls, correlations):
+
+        # TODO: This is not dasky, unlike the other functions. Delayed?
+        parameterisable = ["XX", "YY", "RR", "LL"]
+
+        param_corr = [c for c in correlations if c in parameterisable]
+
+        template = ("tec_{}", "delay_{}")
+
+        return [n.format(c) for c in param_corr for n in template]
+
+    def init_term(self, term_spec, ref_ant, ms_kwargs, term_kwargs):
+        """Initialise the gains (and parameters)."""
+
+        gains, gain_flags, params, param_flags = super().init_term(
+            term_spec, ref_ant, ms_kwargs, term_kwargs
+        )
+
+        # Convert the parameters into gains.
+        delay_and_tec_params_to_gains(
+            params,
+            gains,
+            ms_kwargs["CHAN_FREQ"],
+            term_kwargs[f"{self.name}_param_freq_map"],
+        )
+
+        if self.load_from or not self.initial_estimate:
+
+            apply_param_flags_to_params(param_flags, params, 0)
+            apply_gain_flags_to_gains(gain_flags, gains)
+
+            return gains, gain_flags, params, param_flags
+
+        data = ms_kwargs["DATA"]  # (row, chan, corr)
+        flags = ms_kwargs["FLAG"]  # (row, chan)
+        a1 = ms_kwargs["ANTENNA1"]
+        a2 = ms_kwargs["ANTENNA2"]
+        chan_freq = ms_kwargs["CHAN_FREQ"]
+        t_map = term_kwargs[f"{term_spec.name}_time_map"]
+        f_map = term_kwargs[f"{term_spec.name}_param_freq_map"]
+        _, n_chan, n_ant, n_dir, n_corr = gains.shape
+
+        # We only need the baselines which include the ref_ant.
+        sel = np.where((a1 == ref_ant) | (a2 == ref_ant))
+        a1 = a1[sel]
+        a2 = a2[sel]
+        t_map = t_map[sel]
+        data = data[sel]
+        flags = flags[sel]
+
+        data[flags == 1] = 0  # Ignore UV-cut, otherwise there may be no est.
+
+        utint = np.unique(t_map)
+        ufint = np.unique(f_map)
+
+        for ut in utint:
+            sel = np.where((t_map == ut) & (a1 != a2))
+            ant_map_pq = np.where(a1[sel] == ref_ant, a2[sel], 0)
+            ant_map_qp = np.where(a2[sel] == ref_ant, a1[sel], 0)
+            ant_map = ant_map_pq + ant_map_qp
+
+            ref_data = np.zeros((n_ant, n_chan, n_corr), dtype=np.complex128)
+            counts = np.zeros((n_ant, n_chan), dtype=int)
+            np.add.at(
+                ref_data,
+                ant_map,
+                data[sel]
+            )
+            np.add.at(
+                counts,
+                ant_map,
+                flags[sel] == 0
+            )
+            np.divide(
+                ref_data,
+                counts[:, :, None],
+                where=counts[:, :, None] != 0,
+                out=ref_data
+            )
+
+            for uf in ufint:
+
+                fsel = np.where(f_map == uf)[0]
+                sel_n_chan = fsel.size
+                n = int(np.ceil(2 ** 15 / sel_n_chan)) * sel_n_chan
+
+                fsel_data = ref_data[:, fsel]
+                valid_ant = fsel_data.any(axis=(1, 2))
+
+                fft_data = np.abs(
+                    np.fft.fft(fsel_data, n=n, axis=1)
+                )
+                fft_data = np.fft.fftshift(fft_data, axes=1)
+
+                delta_freq = chan_freq[1] - chan_freq[0]
+                fft_freq = np.fft.fftfreq(n, delta_freq)
+                fft_freq = np.fft.fftshift(fft_freq)
+
+                delay_est_ind_00 = np.argmax(fft_data[..., 0], axis=1)
+                delay_est_00 = fft_freq[delay_est_ind_00]
+                delay_est_00[~valid_ant] = 0
+
+                if n_corr > 1:
+                    delay_est_ind_11 = np.argmax(fft_data[..., -1], axis=1)
+                    delay_est_11 = fft_freq[delay_est_ind_11]
+                    delay_est_11[~valid_ant] = 0
+
+                for t, p, q in zip(t_map[sel], a1[sel], a2[sel]):
+                    if p == ref_ant:
+                        params[t, uf, q, 0, 1] = -delay_est_00[q]
+                        if n_corr > 1:
+                            params[t, uf, q, 0, 3] = -delay_est_11[q]
+                    else:
+                        params[t, uf, p, 0, 1] = delay_est_00[p]
+                        if n_corr > 1:
+                            params[t, uf, p, 0, 3] = delay_est_11[p]
+
+        delay_and_tec_params_to_gains(
+            params,
+            gains,
+            ms_kwargs["CHAN_FREQ"],
+            term_kwargs[f"{self.name}_param_freq_map"],
+        )
+
+        apply_param_flags_to_params(param_flags, params, 0)
+        apply_gain_flags_to_gains(gain_flags, gains)
+
+        return gains, gain_flags, params, param_flags

--- a/testing/tests/gains/test_delay_and_tec.py
+++ b/testing/tests/gains/test_delay_and_tec.py
@@ -1,0 +1,200 @@
+from copy import deepcopy
+import pytest
+import numpy as np
+import dask.array as da
+from quartical.calibration.calibrate import add_calibration_graph
+from testing.utils.gains import apply_gains, reference_gains
+
+
+@pytest.fixture(scope="module")
+def opts(base_opts, select_corr):
+
+    # Don't overwrite base config - instead create a copy and update.
+
+    _opts = deepcopy(base_opts)
+
+    _opts.input_ms.select_corr = select_corr
+    _opts.solver.terms = ['G']
+    _opts.solver.iter_recipe = [100]
+    _opts.solver.propagate_flags = False
+    _opts.solver.convergence_criteria = 1e-7
+    _opts.solver.convergence_fraction = 1
+    _opts.solver.threads = 2
+    _opts.G.type = "delay_and_tec"
+    _opts.G.freq_interval = 0
+
+    return _opts
+
+
+@pytest.fixture(scope="module")
+def raw_xds_list(read_xds_list_output):
+    # Only use the first xds. This overloads the global fixture.
+    return read_xds_list_output[0][:1]
+
+
+@pytest.fixture(scope="module")
+def true_gain_list(predicted_xds_list):
+
+    gain_list = []
+
+    for xds in predicted_xds_list:
+
+        n_ant = xds.sizes["ant"]
+        utime_chunks = xds.UTIME_CHUNKS
+        n_time = sum(utime_chunks)
+        chan_chunks = xds.chunks["chan"]
+        n_chan = xds.sizes["chan"]
+        n_dir = xds.sizes["dir"]
+        n_corr = xds.sizes["corr"]
+
+        chan_freq = xds.CHAN_FREQ.data
+        chan_width = chan_freq[1] - chan_freq[0]
+        cf_min = chan_freq.min()
+        cf_max = chan_freq.max()
+        band_centre = (cf_min + cf_max) / 2
+
+        max_tec = 1/(1/chan_freq[-1] - 1/chan_freq[-2])
+
+        chunking = (utime_chunks, chan_chunks, n_ant, n_dir, n_corr)
+        tec_chunking = (utime_chunks, 1, n_ant, n_dir, n_corr)
+
+        da.random.seed(0)
+        tec = da.random.uniform(
+            size=(n_time, 1, n_ant, n_dir, n_corr),
+            low=-0.05*max_tec,
+            high=0.05*max_tec,
+            chunks=tec_chunking
+        )
+        tec[:, :, 0, :, :] = 0  # Zero the reference antenna for safety.
+
+        delays = da.random.uniform(
+            size=(n_time, 1, n_ant, n_dir, n_corr),
+            low=-1/(2*chan_width),
+            high=1/(2*chan_width)
+        )
+        delays *= 0.2  # Remove once we have initial enstimates.
+        delays[:, :, 0, :, :] = 0  # Zero the reference antenna for safety.
+
+        amp = da.ones((n_time, n_chan, n_ant, n_dir, n_corr),
+                      chunks=chunking)
+
+        if n_corr == 4:  # This solver only considers the diagonal elements.
+            amp *= da.array([1, 0, 0, 1])
+
+        tec_offset = np.log(cf_min/cf_max)/(cf_max - cf_min)
+        tec_coeff = \
+            2 * np.pi * (1/chan_freq[None, :, None, None, None] + tec_offset)
+        delay_coeff = \
+            2*np.pi*(chan_freq[None, :, None, None, None] - band_centre)
+
+        phase = tec*tec_coeff + delays*delay_coeff 
+        gains = amp*da.exp(1j*phase)
+
+        gain_list.append(gains)
+
+    return gain_list
+
+
+@pytest.fixture(scope="module")
+def corrupted_data_xds_list(predicted_xds_list, true_gain_list):
+
+    corrupted_data_xds_list = []
+
+    for xds, gains in zip(predicted_xds_list, true_gain_list):
+
+        n_corr = xds.sizes["corr"]
+
+        ant1 = xds.ANTENNA1.data
+        ant2 = xds.ANTENNA2.data
+        time = xds.TIME.data
+
+        row_inds = \
+            time.map_blocks(lambda x: np.unique(x, return_inverse=True)[1])
+
+        model = da.ones(xds.MODEL_DATA.data.shape, dtype=np.complex128)
+
+        data = da.blockwise(apply_gains, ("rfc"),
+                            model, ("rfdc"),
+                            gains, ("rfadc"),
+                            ant1, ("r"),
+                            ant2, ("r"),
+                            row_inds, ("r"),
+                            n_corr, None,
+                            align_arrays=False,
+                            concatenate=True,
+                            dtype=model.dtype)
+
+        corrupted_xds = xds.assign({
+            "DATA": ((xds.DATA.dims), data),
+            "MODEL_DATA": ((xds.MODEL_DATA.dims), model),
+            "FLAG": ((xds.FLAG.dims), da.zeros_like(xds.FLAG.data)),
+            "WEIGHT": ((xds.WEIGHT.dims), da.ones_like(xds.WEIGHT.data))
+            }
+        )
+
+        corrupted_data_xds_list.append(corrupted_xds)
+
+    return corrupted_data_xds_list
+
+
+@pytest.fixture(scope="module")
+def add_calibration_graph_outputs(corrupted_data_xds_list, stats_xds_list,
+                                  solver_opts, chain, output_opts):
+    # Overload this fixture as we need to use the corrupted xdss.
+    return add_calibration_graph(corrupted_data_xds_list, stats_xds_list,
+                                 solver_opts, chain, output_opts)
+
+
+# -----------------------------------------------------------------------------
+
+def test_residual_magnitude(cmp_post_solve_data_xds_list):
+    # Magnitude of the residuals should tend to zero.
+    for xds in cmp_post_solve_data_xds_list:
+        residual = xds._RESIDUAL.data
+        if residual.shape[-1] == 4:
+            residual = residual[..., (0, 3)]  # Only check on-diagonal terms.
+        np.testing.assert_array_almost_equal(np.abs(residual), 0)
+
+
+def test_solver_flags(cmp_post_solve_data_xds_list):
+    # The solver should not add addiitonal flags to the test data.
+    for xds in cmp_post_solve_data_xds_list:
+        np.testing.assert_array_equal(xds._FLAG.data, xds.FLAG.data)
+
+
+def test_gains(cmp_gain_xds_lod, true_gain_list):
+
+    for solved_gain_dict, true_gain in zip(cmp_gain_xds_lod, true_gain_list):
+        solved_gain_xds = solved_gain_dict["G"]
+        solved_gain, solved_flags = da.compute(solved_gain_xds.gains.data,
+                                               solved_gain_xds.gain_flags.data)
+        true_gain = true_gain.compute()  # TODO: This could be done elsewhere.
+
+        n_corr = true_gain.shape[-1]
+
+        solved_gain = reference_gains(solved_gain, n_corr)
+        true_gain = reference_gains(true_gain, n_corr)
+
+        true_gain[np.where(solved_flags)] = 0
+        solved_gain[np.where(solved_flags)] = 0
+
+        # To ensure the missing antenna handling doesn't render this test
+        # useless, check that we have non-zero entries first.
+        assert np.any(solved_gain), "All gains are zero!"
+        np.testing.assert_array_almost_equal(true_gain, solved_gain)
+
+
+def test_gain_flags(cmp_gain_xds_lod):
+
+    for solved_gain_dict in cmp_gain_xds_lod:
+        solved_gain_xds = solved_gain_dict["G"]
+        solved_flags = solved_gain_xds.gain_flags.values
+
+        frows, fchans, fants, fdir = np.where(solved_flags)
+
+        # We know that these antennas are missing in the test data. No other
+        # antennas should have flags.
+        assert set(np.unique(fants)) == {18, 20}
+
+
+# -----------------------------------------------------------------------------


### PR DESCRIPTION
@rcyndie This PR adds a new term type called `delay_and_tec` which includes both effects (but not a global phase offset). It should be very familiar to you, and I have left the existing delay estimate code as is. You can pull these changes to your local branch and work on integrating the combined initial estimates. Note that you should now be able to solve after estimating, and that the `params_to_gains` function should already be correct. The parameters are laid out as `[tec_XX, delay_XX, tec_YY, delay_YY]`.