### PR TITLE
EXPERIMENTAL: Add a crosshand phase solver which expolits the zero Stokes V assumption. 

### DIFF
--- a/quartical/gains/__init__.py
+++ b/quartical/gains/__init__.py
@@ -6,7 +6,7 @@ from quartical.gains.delay_and_offset import DelayAndOffset
 from quartical.gains.tec_and_offset import TecAndOffset
 from quartical.gains.rotation import Rotation
 from quartical.gains.rotation_measure import RotationMeasure
-from quartical.gains.crosshand_phase import CrosshandPhase
+from quartical.gains.crosshand_phase import CrosshandPhase, CrosshandPhaseNullV
 from quartical.gains.leakage import Leakage
 from quartical.gains.delay_and_tec import DelayAndTec
 
@@ -22,6 +22,7 @@ TERM_TYPES = {
     "rotation": Rotation,
     "rotation_measure": RotationMeasure,
     "crosshand_phase": CrosshandPhase,
+    "crosshand_phase_null_v": CrosshandPhaseNullV,
     "leakage": Leakage,
     "delay_and_tec": DelayAndTec
 }

--- a/quartical/gains/crosshand_phase/__init__.py
+++ b/quartical/gains/crosshand_phase/__init__.py
@@ -5,6 +5,9 @@ from quartical.gains.crosshand_phase.kernel import (
     crosshand_phase_solver,
     crosshand_params_to_gains
 )
+from quartical.gains.crosshand_phase.null_v_kernel import (
+    null_v_crosshand_phase_solver
+)
 from quartical.gains.general.flagging import (
     apply_gain_flags_to_gains,
     apply_param_flags_to_params
@@ -54,3 +57,8 @@ class CrosshandPhase(ParameterizedGain):
         apply_gain_flags_to_gains(gain_flags, gains)
 
         return gains, gain_flags, params, param_flags
+
+
+class CrosshandPhaseNullV(CrosshandPhase):
+
+    solver = staticmethod(null_v_crosshand_phase_solver)

--- a/quartical/gains/crosshand_phase/null_v_kernel.py
+++ b/quartical/gains/crosshand_phase/null_v_kernel.py
@@ -1,0 +1,651 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+from numba import prange, njit
+from numba.typed import List
+from numba.extending import overload
+from quartical.utils.numba import (coerce_literal,
+                                   JIT_OPTIONS,
+                                   PARALLEL_JIT_OPTIONS)
+from quartical.gains.general.generics import (native_intermediaries,
+                                              upsampled_itermediaries,
+                                              per_array_jhj_jhr,
+                                              resample_solints,
+                                              downsample_jhj_jhr,
+                                              invert_gains)
+from quartical.gains.general.flagging import (flag_intermediaries,
+                                              update_gain_flags,
+                                              finalize_gain_flags,
+                                              apply_gain_flags_to_flag_col,
+                                              update_param_flags)
+from quartical.gains.general.convenience import (get_row,
+                                                 get_extents)
+import quartical.gains.general.factories as factories
+from quartical.gains.general.inversion import (invert_factory,
+                                               inversion_buffer_factory)
+
+
+def get_identity_params(corr_mode):
+
+    if corr_mode.literal_value == 4:
+        return np.zeros((1,), dtype=np.float64)
+    else:
+        raise ValueError("Unsupported number of correlations.")
+
+
+@njit(**JIT_OPTIONS)
+def null_v_crosshand_phase_solver(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+    return null_v_crosshand_phase_solver_impl(
+        ms_inputs,
+        mapping_inputs,
+        chain_inputs,
+        meta_inputs,
+        corr_mode
+    )
+
+
+def null_v_crosshand_phase_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(null_v_crosshand_phase_solver_impl, jit_options=JIT_OPTIONS)
+def nb_null_v_crosshand_phase_solver_impl(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    corr_mode
+):
+
+    coerce_literal(nb_null_v_crosshand_phase_solver_impl, ["corr_mode"])
+
+    identity_params = get_identity_params(corr_mode)
+
+    def impl(
+        ms_inputs,
+        mapping_inputs,
+        chain_inputs,
+        meta_inputs,
+        corr_mode
+    ):
+
+        gains = chain_inputs.gains
+        inverse_gain_list = List()
+
+        for gain_term in gains:
+            inverse_gain_list.append(np.empty_like(gain_term))
+        invert_gains(gains, inverse_gain_list, corr_mode)
+
+        gains = inverse_gain_list  # Gains are now the gain inverses.
+        gain_flags = chain_inputs.gain_flags  # Reverse order.
+
+        # Active term in reversed gain list.
+        active_term = meta_inputs.active_term
+        max_iter = meta_inputs.iters
+        solve_per = meta_inputs.solve_per
+        dd_term = meta_inputs.dd_term
+        n_thread = meta_inputs.threads
+
+        active_gain = gains[active_term]
+        active_gain_flags = gain_flags[active_term]
+        active_params = chain_inputs.params[active_term]
+
+        # Set up some intemediaries used for flagging.
+        km1_gain = active_gain.copy()
+        km1_abs2_diffs = np.zeros_like(active_gain_flags, dtype=np.float64)
+        abs2_diffs_trend = np.zeros_like(active_gain_flags, dtype=np.float64)
+        flag_imdry = \
+            flag_intermediaries(km1_gain, km1_abs2_diffs, abs2_diffs_trend)
+
+        # Set up some intemediaries used for solving.
+        real_dtype = active_gain.real.dtype
+        param_shape = active_params.shape
+
+        active_t_map_g = mapping_inputs.time_maps[active_term]
+        active_f_map_g = mapping_inputs.freq_maps[active_term]
+
+        # Create more work to do in paralllel when needed, else no-op.
+        resampler = resample_solints(active_t_map_g, param_shape, n_thread)
+
+        # Determine the starts and stops of the rows and channels associated
+        # with each solution interval.
+        extents = get_extents(resampler.upsample_t_map, active_f_map_g)
+
+        upsample_shape = resampler.upsample_shape
+        upsampled_jhj = np.empty(upsample_shape + (upsample_shape[-1],),
+                                 dtype=real_dtype)
+        upsampled_jhr = np.empty(upsample_shape, dtype=real_dtype)
+        jhj = upsampled_jhj[:param_shape[0]]
+        jhr = upsampled_jhr[:param_shape[0]]
+        update = np.zeros(param_shape, dtype=real_dtype)
+
+        upsampled_imdry = upsampled_itermediaries(upsampled_jhj, upsampled_jhr)
+        native_imdry = native_intermediaries(jhj, jhr, update)
+
+        for loop_idx in range(max_iter or 1):
+
+            compute_jhj_jhr(
+                ms_inputs,
+                mapping_inputs,
+                chain_inputs,
+                meta_inputs,
+                upsampled_imdry,
+                extents,
+                corr_mode
+            )
+
+            if resampler.active:
+                downsample_jhj_jhr(upsampled_imdry, resampler.downsample_t_map)
+
+            if solve_per == "array":
+                per_array_jhj_jhr(native_imdry)
+
+            if not max_iter:  # Non-solvable term, we just want jhj.
+                conv_perc = 0  # Didn't converge.
+                loop_idx = -1  # Did zero iterations.
+                break
+
+            compute_update(native_imdry, corr_mode)
+
+            finalize_update(
+                chain_inputs,
+                meta_inputs,
+                native_imdry,
+                loop_idx,
+                corr_mode
+            )
+
+            # Check for gain convergence. Produced as a side effect of
+            # flagging. The converged percentage is based on unflagged
+            # intervals.
+            conv_perc = update_gain_flags(
+                chain_inputs,
+                meta_inputs,
+                flag_imdry,
+                loop_idx,
+                corr_mode,
+                numbness=1e9
+            )
+
+            # Propagate gain flags to parameter flags.
+            update_param_flags(
+                mapping_inputs,
+                chain_inputs,
+                meta_inputs,
+                identity_params
+            )
+
+            if conv_perc >= meta_inputs.stop_frac:
+                break
+
+        # NOTE: Removes soft flags and flags points which have bad trends.
+        finalize_gain_flags(
+            chain_inputs,
+            meta_inputs,
+            flag_imdry,
+            corr_mode
+        )
+
+        # Call this one last time to ensure points flagged by finialize are
+        # propagated (in the DI case).
+        if not dd_term:
+            apply_gain_flags_to_flag_col(
+                ms_inputs,
+                mapping_inputs,
+                chain_inputs,
+                meta_inputs
+            )
+
+        return native_imdry.jhj, loop_idx + 1, conv_perc
+
+    return impl
+
+
+def compute_jhj_jhr(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    upsampled_imdry,
+    extents,
+    corr_mode
+):
+    return NotImplementedError
+
+
+@overload(compute_jhj_jhr, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_jhj_jhr(
+    ms_inputs,
+    mapping_inputs,
+    chain_inputs,
+    meta_inputs,
+    upsampled_imdry,
+    extents,
+    corr_mode
+):
+
+    coerce_literal(nb_compute_jhj_jhr, ["corr_mode"])
+
+    # We want to dispatch based on this field so we need its type.
+    row_weights_idx = ms_inputs.fields.index('ROW_WEIGHTS')
+    row_weights_type = ms_inputs[row_weights_idx]
+
+    imul_rweight = factories.imul_rweight_factory(corr_mode, row_weights_type)
+    v1_imul_v2 = factories.v1_imul_v2_factory(corr_mode)
+    v1_imul_v2ct = factories.v1_imul_v2ct_factory(corr_mode)
+    v1ct_imul_v2 = factories.v1ct_imul_v2_factory(corr_mode)
+    absv1_idiv_absv2 = factories.absv1_idiv_absv2_factory(corr_mode)
+    iunpack = factories.iunpack_factory(corr_mode)
+    iunpackct = factories.iunpackct_factory(corr_mode)
+    imul = factories.imul_factory(corr_mode)
+    iadd = factories.iadd_factory(corr_mode)
+    isub = factories.isub_factory(corr_mode)
+    valloc = factories.valloc_factory(corr_mode)
+    make_loop_vars = factories.loop_var_factory(corr_mode)
+    set_identity = factories.set_identity_factory(corr_mode)
+    compute_jhwj_jhwr_elem = compute_jhwj_jhwr_elem_factory(corr_mode)
+
+    def impl(
+        ms_inputs,
+        mapping_inputs,
+        chain_inputs,
+        meta_inputs,
+        upsampled_imdry,
+        extents,
+        corr_mode
+    ):
+
+        active_term = meta_inputs.active_term
+
+        data = ms_inputs.DATA
+        model = ms_inputs.MODEL_DATA
+        weights = ms_inputs.WEIGHT
+        flags = ms_inputs.FLAG
+        antenna1 = ms_inputs.ANTENNA1
+        antenna2 = ms_inputs.ANTENNA2
+        row_map = ms_inputs.ROW_MAP
+        row_weights = ms_inputs.ROW_WEIGHTS
+
+        time_maps = mapping_inputs.time_maps
+        freq_maps = mapping_inputs.freq_maps
+        dir_maps = mapping_inputs.dir_maps
+
+        gains = chain_inputs.gains
+
+        jhj = upsampled_imdry.jhj
+        jhr = upsampled_imdry.jhr
+
+        _, n_chan, n_dir, n_corr = model.shape
+
+        jhj[:] = 0
+        jhr[:] = 0
+
+        n_tint, n_fint, n_ant, n_gdir, n_param = jhr.shape
+        n_int = n_tint*n_fint
+
+        complex_dtype = gains[active_term].dtype
+        weight_dtype = weights.dtype
+
+        n_gains = len(gains)
+
+        row_starts = extents.row_starts
+        row_stops = extents.row_stops
+        chan_starts = extents.chan_starts
+        chan_stops = extents.chan_stops
+
+        # Determine loop variables based on where we are in the chain.
+        # gt means greater than (n>j) and lt means less than (n<j).
+        all_terms, gt_active, lt_active = make_loop_vars(n_gains, active_term)
+
+        # Parallel over all solution intervals.
+        for i in prange(n_int):
+
+            ti = i//n_fint
+            fi = i - ti*n_fint
+
+            rs = row_starts[ti]
+            re = row_stops[ti]
+            fs = chan_starts[fi]
+            fe = chan_stops[fi]
+
+            rop_pq = valloc(complex_dtype)  # Right-multiply operator for pq.
+            rop_qp = valloc(complex_dtype)  # Right-multiply operator for qp.
+            lop_pq = valloc(complex_dtype)  # Left-multiply operator for pq.
+            lop_qp = valloc(complex_dtype)  # Left-multiply operator for qp.
+
+            w = valloc(weight_dtype)
+            r_pq = valloc(complex_dtype)
+            wr_pq = valloc(complex_dtype)
+            wr_qp = valloc(complex_dtype)
+            v_pqd = valloc(complex_dtype)
+            v_pq = valloc(complex_dtype)
+
+            gains_p = valloc(complex_dtype, leading_dims=(n_gains,))
+            gains_q = valloc(complex_dtype, leading_dims=(n_gains,))
+
+            lop_pq_arr = valloc(complex_dtype, leading_dims=(n_gdir,))
+            rop_pq_arr = valloc(complex_dtype, leading_dims=(n_gdir,))
+            lop_qp_arr = valloc(complex_dtype, leading_dims=(n_gdir,))
+            rop_qp_arr = valloc(complex_dtype, leading_dims=(n_gdir,))
+
+            norm_factors = valloc(complex_dtype)
+
+            jhr_tifi = jhr[ti, fi]
+            jhj_tifi = jhj[ti, fi]
+
+            for row_ind in range(rs, re):
+
+                row = get_row(row_ind, row_map)
+                a1_m, a2_m = antenna1[row], antenna2[row]
+
+                for f in range(fs, fe):
+
+                    if flags[row, f]:  # Skip flagged data points.
+                        continue
+
+                    # Apply row weights in the BDA case, otherwise a no-op.
+                    imul_rweight(weights[row, f], w, row_weights, row_ind)
+                    iunpack(r_pq, data[row, f])
+
+                    lop_pq_arr[:] = 0
+                    rop_pq_arr[:] = 0
+                    lop_qp_arr[:] = 0
+                    rop_qp_arr[:] = 0
+                    v_pq[:] = 0
+
+                    for d in range(n_dir):
+
+                        set_identity(lop_pq)
+                        set_identity(lop_qp)
+
+                        # Construct a small contiguous gain array. This makes
+                        # the single term case fractionally slower.
+                        for gi in range(n_gains):
+                            d_m = dir_maps[gi][d]  # Broadcast dir.
+                            t_m = time_maps[gi][row_ind]
+                            f_m = freq_maps[gi][f]
+
+                            gain = gains[gi][t_m, f_m]
+
+                            iunpack(gains_p[gi], gain[a1_m, d_m])
+                            iunpack(gains_q[gi], gain[a2_m, d_m])
+
+                        m = model[row, f, d]
+                        iunpack(rop_qp, m)
+                        iunpackct(rop_pq, rop_qp)
+
+                        for g in all_terms:
+
+                            g_q = gains_q[g]
+                            v1_imul_v2(g_q, rop_pq, rop_pq)
+
+                            g_p = gains_p[g]
+                            v1_imul_v2(g_p, rop_qp, rop_qp)
+
+                        for g in gt_active:
+
+                            g_p = gains_p[g]
+                            v1_imul_v2ct(rop_pq, g_p, rop_pq)
+
+                            g_q = gains_q[g]
+                            v1_imul_v2ct(rop_qp, g_q, rop_qp)
+
+                        for g in lt_active:
+
+                            g_p = gains_p[g]
+                            v1ct_imul_v2(g_p, lop_pq, lop_pq)
+
+                            g_q = gains_q[g]
+                            v1ct_imul_v2(g_q, lop_qp, lop_qp)
+
+                        out_d = dir_maps[active_term][d]
+
+                        iunpack(lop_pq_arr[out_d], lop_pq)
+                        iadd(rop_pq_arr[out_d], rop_pq)
+
+                        iunpack(lop_qp_arr[out_d], lop_qp)
+                        iadd(rop_qp_arr[out_d], rop_qp)
+
+                        v1ct_imul_v2(lop_pq, gains_p[active_term], v_pqd)
+                        v1_imul_v2ct(v_pqd, rop_pq, v_pqd)
+                        iadd(v_pq, v_pqd)
+
+                    absv1_idiv_absv2(v_pq, r_pq, norm_factors)
+                    imul(r_pq, norm_factors)
+                    isub(r_pq, v_pq)
+
+                    for d in range(n_gdir):
+
+                        iunpack(wr_pq, r_pq)
+                        imul(wr_pq, w)
+                        iunpackct(wr_qp, wr_pq)
+
+                        lop_pq_d = lop_pq_arr[d]
+                        rop_pq_d = rop_pq_arr[d]
+
+                        compute_jhwj_jhwr_elem(lop_pq_d,
+                                               rop_pq_d,
+                                               w,
+                                               norm_factors,
+                                               gains_p[active_term],
+                                               wr_pq,
+                                               jhr_tifi[a1_m, d],
+                                               jhj_tifi[a1_m, d])
+
+                        lop_qp_d = lop_qp_arr[d]
+                        rop_qp_d = rop_qp_arr[d]
+
+                        compute_jhwj_jhwr_elem(lop_qp_d,
+                                               rop_qp_d,
+                                               w,
+                                               norm_factors,
+                                               gains_q[active_term],
+                                               wr_qp,
+                                               jhr_tifi[a2_m, d],
+                                               jhj_tifi[a2_m, d])
+        return
+    return impl
+
+
+def compute_update(native_imdry, corr_mode):
+    raise NotImplementedError
+
+
+@overload(compute_update, jit_options=PARALLEL_JIT_OPTIONS)
+def nb_compute_update(native_imdry, corr_mode):
+
+    coerce_literal(nb_compute_update, ["corr_mode"])
+
+    # We want to dispatch based on this field so we need its type.
+    jhj = native_imdry[native_imdry.fields.index('jhj')]
+
+    generalised = jhj.ndim == 6
+    inversion_buffer = inversion_buffer_factory(generalised=generalised)
+    invert = invert_factory(corr_mode, generalised=generalised)
+
+    def impl(native_imdry, corr_mode):
+
+        jhj = native_imdry.jhj
+        jhr = native_imdry.jhr
+        update = native_imdry.update
+
+        n_tint, n_fint, n_ant, n_dir, n_param = jhr.shape
+
+        n_int = n_tint * n_fint
+
+        result_dtype = jhr.dtype
+
+        for i in prange(n_int):
+
+            t = i // n_fint
+            f = i - t * n_fint
+
+            buffers = inversion_buffer(n_param, result_dtype)
+
+            for a in range(n_ant):
+                for d in range(n_dir):
+
+                    invert(jhj[t, f, a, d],
+                           jhr[t, f, a, d],
+                           update[t, f, a, d],
+                           buffers)
+
+    return impl
+
+
+def finalize_update(
+    chain_inputs,
+    meta_inputs,
+    native_imdry,
+    loop_idx,
+    corr_mode
+):
+    raise NotImplementedError
+
+
+@overload(finalize_update, jit_options=JIT_OPTIONS)
+def nb_finalize_update(
+    chain_inputs,
+    meta_inputs,
+    native_imdry,
+    loop_idx,
+    corr_mode
+):
+
+    coerce_literal(nb_finalize_update, ["corr_mode"])
+
+    set_identity = factories.set_identity_factory(corr_mode)
+    param_to_gain = param_to_gain_factory(corr_mode)
+
+    def impl(
+        chain_inputs,
+        meta_inputs,
+        native_imdry,
+        loop_idx,
+        corr_mode
+    ):
+
+        dd_term = meta_inputs.dd_term
+        active_term = meta_inputs.active_term
+        pinned_directions = meta_inputs.pinned_directions
+
+        gain = chain_inputs.gains[active_term]
+        gain_flags = chain_inputs.gain_flags[active_term]
+        params = chain_inputs.params[active_term]
+
+        update = native_imdry.update
+
+        n_tint, n_fint, n_ant, n_dir, n_corr = gain.shape
+
+        if dd_term:
+            dir_loop = [d for d in range(n_dir) if d not in pinned_directions]
+        else:
+            dir_loop = [d for d in range(n_dir)]
+
+        for ti in range(n_tint):
+            for fi in range(n_fint):
+                for a in range(n_ant):
+                    for d in dir_loop:
+
+                        p = params[ti, fi, a, d]
+                        g = gain[ti, fi, a, d]
+                        fl = gain_flags[ti, fi, a, d]
+                        upd = update[ti, fi, a, d]
+
+                        if fl == 1:
+                            p[:] = 0
+                            set_identity(g)
+                        else:
+                            p += upd
+                            param_to_gain(p, g)
+
+    return impl
+
+
+def param_to_gain_factory(corr_mode):
+
+    if corr_mode.literal_value == 4:
+        def impl(params, gain):
+            gain[0] = np.exp(1j*params[0])
+    else:
+        raise ValueError("Crosshand phase can only be solved for with four "
+                         "correlation data.")
+
+    return factories.qcjit(impl)
+
+
+def compute_jhwj_jhwr_elem_factory(corr_mode):
+
+    v1_imul_v2 = factories.v1_imul_v2_factory(corr_mode)
+    unpack = factories.unpack_factory(corr_mode)
+    unpackc = factories.unpackc_factory(corr_mode)
+    iabsdivsq = factories.iabsdivsq_factory(corr_mode)
+    imul = factories.imul_factory(corr_mode)
+
+    if corr_mode.literal_value == 4:
+        def impl(lop, rop, w, normf, gain, res, jhr, jhj):
+
+            # Compute normalization factor.
+            v1_imul_v2(lop, rop, normf)
+            iabsdivsq(normf)
+            imul(res, normf)  # Apply normalization factor to r.
+
+            # Accumulate an element of jhwr.
+            v1_imul_v2(res, rop, res)
+            v1_imul_v2(lop, res, res)
+
+            # Accumulate an element of jhwj.
+
+            r_0, _, _, _ = unpack(res)  # NOTE: XX, XY, YX, YY
+
+            gc_0, _, _, _ = unpackc(gain)
+
+            drv_00 = -1j*gc_0
+
+            upd_00 = (drv_00*r_0).real
+
+            jhr[0] += upd_00
+
+            w_0, w_1, w_2, w_3 = unpack(w)  # NOTE: XX, XY, YX, YY
+            n_0, n_1, n_2, n_3 = unpack(normf)
+
+            # Apply normalisation factors by scaling w.
+            w_0 = n_0 * w_0
+            w_1 = n_1 * w_1
+            w_2 = n_2 * w_2
+            w_3 = n_3 * w_3
+
+            lop_00, lop_01, _, _ = unpack(lop)
+            rop_00, _, rop_01, _ = unpack(rop)  # "Transpose"
+
+            jh_00 = lop_00 * rop_00
+            jh_01 = lop_00 * rop_01
+            jh_02 = lop_01 * rop_00
+            jh_03 = lop_01 * rop_01
+
+            j_00 = jh_00.conjugate()
+            j_01 = jh_01.conjugate()
+            j_02 = jh_02.conjugate()
+            j_03 = jh_03.conjugate()
+
+            jhwj_00 = jh_00*w_0*j_00 + jh_01*w_1*j_01 + \
+                      jh_02*w_2*j_02 + jh_03*w_3*j_03  # noqa
+
+            jhj[0, 0] += jhwj_00.real
+
+    else:
+        raise ValueError("Crosshand phase can only be solved for with four "
+                         "correlation data.")
+
+    return factories.qcjit(impl)

--- a/testing/tests/gains/test_crosshand_phase_null_v.py
+++ b/testing/tests/gains/test_crosshand_phase_null_v.py
@@ -125,10 +125,12 @@ def add_calibration_graph_outputs(corrupted_data_xds_list, stats_xds_list,
 
 # -----------------------------------------------------------------------------
 
-def test_residual_magnitude(cmp_post_solve_data_xds_list):
-    # Magnitude of the residuals should tend to zero.
+def test_stokes_v_magnitude(cmp_post_solve_data_xds_list):
+    # Magnitude of stokes V in the corrected data should tend to zero.
     for xds in cmp_post_solve_data_xds_list:
-        np.testing.assert_array_almost_equal(np.abs(xds._RESIDUAL.data), 0)
+        corr_data = xds._CORRECTED_DATA.data
+        res_v = -0.5j*corr_data[...,1] + 0.5j*corr_data[..., 2]
+        np.testing.assert_array_almost_equal(np.abs(res_v), 0)
 
 
 def test_solver_flags(cmp_post_solve_data_xds_list):

--- a/testing/tests/gains/test_crosshand_phase_null_v.py
+++ b/testing/tests/gains/test_crosshand_phase_null_v.py
@@ -1,0 +1,169 @@
+from copy import deepcopy
+import pytest
+import numpy as np
+import dask.array as da
+from quartical.calibration.calibrate import add_calibration_graph
+from testing.utils.gains import apply_gains
+
+
+@pytest.fixture(scope="module")
+def opts(base_opts):
+
+    # Don't overwrite base config - instead create a copy and update.
+
+    _opts = deepcopy(base_opts)
+
+    _opts.input_ms.select_corr = [0, 1, 2, 3]
+    _opts.solver.terms = ['G']
+    _opts.solver.iter_recipe = [100]
+    _opts.solver.propagate_flags = False
+    _opts.solver.convergence_criteria = 1e-7
+    _opts.solver.convergence_fraction = 1
+    _opts.solver.threads = 2
+    _opts.G.time_interval = 0
+    _opts.G.type = "crosshand_phase_null_v"
+    _opts.G.solve_per = "array"
+
+    return _opts
+
+
+@pytest.fixture(scope="module")
+def raw_xds_list(read_xds_list_output):
+    # Only use the first xds. This overloads the global fixture.
+    return read_xds_list_output[0][:1]
+
+
+@pytest.fixture(scope="module")
+def true_gain_list(predicted_xds_list):
+
+    gain_list = []
+
+    for xds in predicted_xds_list:
+
+        n_ant = xds.sizes["ant"]
+        utime_chunks = xds.UTIME_CHUNKS
+        n_time = sum(utime_chunks)
+        chan_chunks = xds.chunks["chan"]
+        n_chan = xds.sizes["chan"]
+        n_dir = xds.sizes["dir"]
+        n_corr = xds.sizes["corr"]
+
+        chunking = (len(utime_chunks), chan_chunks, n_ant, n_dir, n_corr)
+
+        bound = np.pi
+
+        da.random.seed(0)
+        amp = da.from_array(np.array([1, 0, 0, 1]))
+        phase = da.random.uniform(size=(1, n_chan, 1, n_dir, n_corr),
+                                  high=bound,
+                                  low=-bound,
+                                  chunks=chunking)
+        phase[..., 1:] = 0  # Only introduce the phase on XX or RR.
+
+        gains = amp[None, None, None, None, :]*da.exp(1j*phase)
+
+        shape = (n_time, n_chan, n_ant, n_dir, n_corr)
+
+        gains = da.broadcast_to(gains[:, :, :1], shape)
+
+        gain_list.append(gains)
+
+    return gain_list
+
+
+@pytest.fixture(scope="module")
+def corrupted_data_xds_list(predicted_xds_list, true_gain_list):
+
+    corrupted_data_xds_list = []
+
+    for xds, gains in zip(predicted_xds_list, true_gain_list):
+
+        n_corr = xds.sizes["corr"]
+
+        ant1 = xds.ANTENNA1.data
+        ant2 = xds.ANTENNA2.data
+        time = xds.TIME.data
+
+        row_inds = \
+            time.map_blocks(lambda x: np.unique(x, return_inverse=True)[1])
+
+        model = da.ones(xds.MODEL_DATA.data.shape, dtype=np.complex128)
+
+        model *= da.from_array([1, 0.1, 0.1, 1])
+
+        data = da.blockwise(apply_gains, ("rfc"),
+                            model, ("rfdc"),
+                            gains, ("rfadc"),
+                            ant1, ("r"),
+                            ant2, ("r"),
+                            row_inds, ("r"),
+                            n_corr, None,
+                            align_arrays=False,
+                            concatenate=True,
+                            dtype=model.dtype)
+
+        corrupted_xds = xds.assign({
+            "DATA": ((xds.DATA.dims), data),
+            "MODEL_DATA": ((xds.MODEL_DATA.dims), model),
+            "FLAG": ((xds.FLAG.dims), da.zeros_like(xds.FLAG.data)),
+            "WEIGHT": ((xds.WEIGHT.dims), da.ones_like(xds.WEIGHT.data))
+            }
+        )
+
+        corrupted_data_xds_list.append(corrupted_xds)
+
+    return corrupted_data_xds_list
+
+
+@pytest.fixture(scope="module")
+def add_calibration_graph_outputs(corrupted_data_xds_list, stats_xds_list,
+                                  solver_opts, chain, output_opts):
+    # Overload this fixture as we need to use the corrupted xdss.
+    return add_calibration_graph(corrupted_data_xds_list, stats_xds_list,
+                                 solver_opts, chain, output_opts)
+
+
+# -----------------------------------------------------------------------------
+
+def test_residual_magnitude(cmp_post_solve_data_xds_list):
+    # Magnitude of the residuals should tend to zero.
+    for xds in cmp_post_solve_data_xds_list:
+        np.testing.assert_array_almost_equal(np.abs(xds._RESIDUAL.data), 0)
+
+
+def test_solver_flags(cmp_post_solve_data_xds_list):
+    # The solver should not add addiitonal flags to the test data.
+    for xds in cmp_post_solve_data_xds_list:
+        np.testing.assert_array_equal(xds._FLAG.data, xds.FLAG.data)
+
+
+def test_gains(cmp_gain_xds_lod, true_gain_list):
+
+    for solved_gain_dict, true_gain in zip(cmp_gain_xds_lod, true_gain_list):
+        solved_gain_xds = solved_gain_dict["G"]
+        solved_gain, solved_flags = da.compute(solved_gain_xds.gains.data,
+                                               solved_gain_xds.gain_flags.data)
+        true_gain = true_gain.compute().copy()  # Make mutable.
+
+        true_gain[np.where(solved_flags)] = 0
+        solved_gain[np.where(solved_flags)] = 0
+
+        # To ensure the missing antenna handling doesn't render this test
+        # useless, check that we have non-zero entries first.
+        assert np.any(solved_gain), "All gains are zero!"
+        np.testing.assert_array_almost_equal(true_gain[:1], solved_gain)
+
+
+def test_gain_flags(cmp_gain_xds_lod):
+
+    for solved_gain_dict in cmp_gain_xds_lod:
+        solved_gain_xds = solved_gain_dict["G"]
+        solved_flags = solved_gain_xds.gain_flags.values
+
+        frows, fchans, fants, fdir = np.where(solved_flags)
+
+        # We know that these antennas are missing in the test data. No other
+        # antennas should have flags.
+        assert set(np.unique(fants)) == {18, 20}
+
+# -----------------------------------------------------------------------------


### PR DESCRIPTION
@landmanbester I believe this is a working prototype of the solver component of zero Stokes V approach. It is by no means complete, and I have not yet tested it in a chain.

There is still a fair amount of additional work to be done, including:

- [ ] Include an explicit parallactic angle Jones term. This is required for this specific case as its inverse needs to be applied to the data on the fly inside the solver.
- [ ] Make it possible for users to add pi radians to the output phases/specify the expected sign of Stokes U. There is an ambiguity in the results as both `visibility = [1, 1, 1, 1]` and `visibility = [1, -1, -1, 1]` correspond to zero Stokes V i.e. there are two valid solutions for the crosshand phase.
- [ ] Fix residual computations as the residual will be somewhat meaningless for a term which doesn't actually have a model. A more useful metric would be the residual Stokes V.
- [ ] (Possibly) Add a mechanism for identifying circular feeds and doing an on the fly conversion to linear feeds so that the zero Stokes V assumption can be used regardless of the actual feed type. See http://www.aips.nrao.edu/TEXT/PUBL/AIPSMEM125.PDF for the conversion matrices.