### PR TITLE
Add feed flip term.

### DIFF
--- a/quartical/calibration/solver.py
+++ b/quartical/calibration/solver.py
@@ -229,7 +229,8 @@ def solver_wrapper(
                 corr_mode
             )
         else:
-            jhj = np.zeros(getattr(active_spec, "pshape", active_spec.shape))
+            pshape, gshape = active_spec.pshape, active_spec.shape
+            jhj = np.zeros(pshape if term.is_parameterized else gshape)
             conv_iter, conv_perc = 0, 1
 
         # If reweighting is enabled, do it when the epoch changes, except

--- a/quartical/config/gain_schema.yaml
+++ b/quartical/config/gain_schema.yaml
@@ -17,6 +17,7 @@ gain:
       - crosshand_phase_null_v
       - leakage
       - parallactic_angle
+      - feed_flip
     info:
       Type of gain to solve for.
 

--- a/quartical/gains/__init__.py
+++ b/quartical/gains/__init__.py
@@ -10,6 +10,7 @@ from quartical.gains.crosshand_phase import CrosshandPhase, CrosshandPhaseNullV
 from quartical.gains.leakage import Leakage
 from quartical.gains.delay_and_tec import DelayAndTec
 from quartical.gains.parallactic_angle import ParallacticAngle
+from quartical.gains.feed_flip import FeedFlip
 
 
 TERM_TYPES = {
@@ -26,5 +27,6 @@ TERM_TYPES = {
     "crosshand_phase_null_v": CrosshandPhaseNullV,
     "leakage": Leakage,
     "delay_and_tec": DelayAndTec,
-    "parallactic_angle": ParallacticAngle
+    "parallactic_angle": ParallacticAngle,
+    "feed_flip": FeedFlip
 }

--- a/quartical/gains/feed_flip/__init__.py
+++ b/quartical/gains/feed_flip/__init__.py
@@ -42,6 +42,6 @@ class FeedFlip(Gain):
                 "Feed flip unsupported for less than four correlations"
             )
 
-        gain_flags = np.zeros(gains.shape[:-1], dtype=bool)
+        gain_flags = np.zeros(gains.shape[:-1], dtype=np.int8)
 
         return gains, gain_flags

--- a/quartical/gains/feed_flip/__init__.py
+++ b/quartical/gains/feed_flip/__init__.py
@@ -1,0 +1,47 @@
+import numpy as np
+from quartical.gains.gain import Gain
+from quartical.gains.conversion import amp_trig_to_complex
+
+
+class FeedFlip(Gain):
+
+    solver = None # This is not a solvable term.
+    # Conversion functions required for interpolation NOTE: Non-parameterised
+    # gains will always be reinterpreted and parameterised in amplitude and
+    # phase for the sake of simplicity.
+    # TODO: Make this a real valued term - took simple approach for now.
+    native_to_converted = (
+        (0, (np.abs,)),
+        (0, (np.angle, np.cos)),
+        (1, (np.angle, np.sin))
+    )
+    converted_to_native = (
+        (3, amp_trig_to_complex),
+    )
+    converted_dtype = np.float64
+    native_dtype = np.complex128
+
+    def __init__(self, term_name, term_opts):
+
+        super().__init__(term_name, term_opts)
+
+        self.time_interval = 0
+        self.freq_interval = 0
+
+    def init_term(self, term_spec, ref_ant, ms_kwargs, term_kwargs, meta=None):
+        """Initialise the gains (and parameters)."""
+
+        (_, _, gain_shape, _) = term_spec
+
+        gains = np.ones(gain_shape, dtype=np.complex128)
+
+        if gain_shape[-1] == 4:
+            gains[..., (0, 3)] = 0  # 2-by-2 antidiagonal.
+        else:
+            raise ValueError(
+                "Feed flip unsupported for less than four correlations"
+            )
+
+        gain_flags = np.zeros(gains.shape[:-1], dtype=bool)
+
+        return gains, gain_flags


### PR DESCRIPTION
Finally caving to @o-smirnov and @bennahugo's requests. This adds an explicit feed flip term. This can be included in your `solver.terms` by selecting type `feed_flip`. Note that if you require parallactic angle correction, you should use the newly added explicit `parallactic_angle` term and not the `input_model.apply_p_jones` and `output.apply_p_jones_inv` options. The current approach will up computational complexity - I will work on improving this but it will be a big job as I will need to refactor how the gains are collapsed within the chain. That will likely be a separate future PR. 

Currently unanswered questions:

- Are the weights also flipped?
- Is simply including the flip in the chain sufficient to address the problem?