### PR TITLE
Add a scalar mode to diagonal parameterised Jones terms

### DIFF
--- a/quartical/calibration/solver.py
+++ b/quartical/calibration/solver.py
@@ -18,6 +18,7 @@ meta_args_nt = namedtuple(
         "threads",
         "robust",
         "reference_antenna",
+        "scalar",
         "dd_term",
         "pinned_directions",
         "solve_per",
@@ -215,6 +216,7 @@ def solver_wrapper(
             solver_opts.threads,
             solver_opts.robust,
             solver_opts.reference_antenna,
+            term.scalar,
             term.direction_dependent,
             term.pinned_directions,
             term.solve_per

--- a/quartical/config/gain_schema.yaml
+++ b/quartical/config/gain_schema.yaml
@@ -28,9 +28,17 @@ gain:
       Determines whether this term should be solved per antenna (conventional)
       or over the entire array (doesn't vary with antenna).
 
+  scalar:
+    dtype: bool
+    default: false
+    info:
+      Determines whether the term is treated as scalar i.e. whether it is
+      solved for as a single effect over all correlations. This is only
+      supported for terms which would otherwise be diagonal.
+
   direction_dependent:
     dtype: bool
-    default: False
+    default: false
     info:
       Determines whether this term is treated as direction dependent.
 

--- a/quartical/gains/amplitude/kernel.py
+++ b/quartical/gains/amplitude/kernel.py
@@ -146,7 +146,7 @@ def nb_amplitude_solver_impl(
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
 
-            if scalar:
+            if scalar and corr_mode != 1:
                 scalar_jhj_jhr(native_imdry, 1)
 
             if not max_iter:  # Non-solvable term, we just want jhj.

--- a/quartical/gains/amplitude/kernel.py
+++ b/quartical/gains/amplitude/kernel.py
@@ -9,7 +9,8 @@ from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
                                               resample_solints,
-                                              downsample_jhj_jhr)
+                                              downsample_jhj_jhr,
+                                              scalar_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
@@ -86,6 +87,7 @@ def nb_amplitude_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -143,6 +145,9 @@ def nb_amplitude_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                scalar_jhj_jhr(native_imdry, 1)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/complex/diag_kernel.py
+++ b/quartical/gains/complex/diag_kernel.py
@@ -74,6 +74,7 @@ def nb_diag_complex_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -128,6 +129,12 @@ def nb_diag_complex_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError(
+                    "Scalar mode not (yet) supported for diag complex terms."
+                    "Please raise an issue if you require this functionality."
+                )
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/complex/diag_kernel.py
+++ b/quartical/gains/complex/diag_kernel.py
@@ -130,7 +130,7 @@ def nb_diag_complex_solver_impl(
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
 
-            if scalar:
+            if scalar and corr_mode != 1:
                 scalar_jhj_jhr(native_imdry)
 
             if not max_iter:  # Non-solvable term, we just want jhj.

--- a/quartical/gains/complex/kernel.py
+++ b/quartical/gains/complex/kernel.py
@@ -75,6 +75,7 @@ def nb_complex_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -131,6 +132,9 @@ def nb_complex_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError("Scalar mode not supported for complex terms.")
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/crosshand_phase/kernel.py
+++ b/quartical/gains/crosshand_phase/kernel.py
@@ -84,6 +84,7 @@ def nb_crosshand_phase_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -140,6 +141,11 @@ def nb_crosshand_phase_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError(
+                    "Scalar mode not supported for crosshand phase terms."
+                )
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/crosshand_phase/null_v_kernel.py
+++ b/quartical/gains/crosshand_phase/null_v_kernel.py
@@ -91,6 +91,7 @@ def nb_null_v_crosshand_phase_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -148,6 +149,11 @@ def nb_null_v_crosshand_phase_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError(
+                    "Scalar mode not supported for crosshand phase terms."
+                )
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -12,7 +12,8 @@ from quartical.gains.general.generics import (
     upsampled_itermediaries,
     per_array_jhj_jhr,
     resample_solints,
-    downsample_jhj_jhr
+    downsample_jhj_jhr,
+    scalar_jhj_jhr
 )
 from quartical.gains.general.flagging import (
     flag_intermediaries,
@@ -94,6 +95,7 @@ def nb_delay_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -156,6 +158,9 @@ def nb_delay_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                scalar_jhj_jhr(native_imdry, 1)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -159,7 +159,7 @@ def nb_delay_solver_impl(
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
 
-            if scalar:
+            if scalar and corr_mode != 1:
                 scalar_jhj_jhr(native_imdry, 1)
 
             if not max_iter:  # Non-solvable term, we just want jhj.

--- a/quartical/gains/delay_and_offset/kernel.py
+++ b/quartical/gains/delay_and_offset/kernel.py
@@ -2,26 +2,34 @@
 import numpy as np
 from numba import prange, njit
 from numba.extending import overload
-from quartical.utils.numba import (coerce_literal,
-                                   JIT_OPTIONS,
-                                   PARALLEL_JIT_OPTIONS)
-from quartical.gains.general.generics import (native_intermediaries,
-                                              upsampled_itermediaries,
-                                              per_array_jhj_jhr,
-                                              resample_solints,
-                                              downsample_jhj_jhr)
-from quartical.gains.general.flagging import (flag_intermediaries,
-                                              update_gain_flags,
-                                              finalize_gain_flags,
-                                              apply_gain_flags_to_flag_col,
-                                              update_param_flags,
-                                              apply_gain_flags_to_gains,
-                                              apply_param_flags_to_params)
-from quartical.gains.general.convenience import (get_row,
-                                                 get_extents)
+from quartical.utils.numba import (
+    coerce_literal,
+    JIT_OPTIONS,
+    PARALLEL_JIT_OPTIONS
+)
+from quartical.gains.general.generics import (
+    native_intermediaries,
+    upsampled_itermediaries,
+    per_array_jhj_jhr,
+    resample_solints,
+    downsample_jhj_jhr,
+    scalar_jhj_jhr
+)
+from quartical.gains.general.flagging import (
+    flag_intermediaries,
+    update_gain_flags,
+    finalize_gain_flags,
+    apply_gain_flags_to_flag_col,
+    update_param_flags,
+    apply_gain_flags_to_gains,
+    apply_param_flags_to_params
+)
+from quartical.gains.general.convenience import get_row, get_extents
 import quartical.gains.general.factories as factories
-from quartical.gains.general.inversion import (invert_factory,
-                                               inversion_buffer_factory)
+from quartical.gains.general.inversion import (
+    invert_factory,
+    inversion_buffer_factory
+)
 
 
 def get_identity_params(corr_mode):
@@ -88,6 +96,7 @@ def nb_delay_and_offset_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -150,6 +159,9 @@ def nb_delay_and_offset_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                scalar_jhj_jhr(native_imdry, 2)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/delay_and_offset/kernel.py
+++ b/quartical/gains/delay_and_offset/kernel.py
@@ -160,7 +160,7 @@ def nb_delay_and_offset_solver_impl(
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
 
-            if scalar:
+            if scalar and corr_mode != 1:
                 scalar_jhj_jhr(native_imdry, 2)
 
             if not max_iter:  # Non-solvable term, we just want jhj.

--- a/quartical/gains/delay_and_tec/kernel.py
+++ b/quartical/gains/delay_and_tec/kernel.py
@@ -157,7 +157,7 @@ def nb_delay_and_tec_solver_impl(
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
 
-            if scalar:
+            if scalar and corr_mode != 1:
                 scalar_jhj_jhr(native_imdry, 2)
 
             if not max_iter:  # Non-solvable term, we just want jhj.

--- a/quartical/gains/delay_and_tec/kernel.py
+++ b/quartical/gains/delay_and_tec/kernel.py
@@ -9,7 +9,8 @@ from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
                                               resample_solints,
-                                              downsample_jhj_jhr)
+                                              downsample_jhj_jhr,
+                                              scalar_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
@@ -88,6 +89,7 @@ def nb_delay_and_tec_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -154,6 +156,9 @@ def nb_delay_and_tec_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                scalar_jhj_jhr(native_imdry, 2)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/gain.py
+++ b/quartical/gains/gain.py
@@ -85,6 +85,7 @@ class Gain:
         self.name = term_name
         self.type = term_opts.type
         self.solve_per = term_opts.solve_per
+        self.scalar = term_opts.scalar
         self.direction_dependent = term_opts.direction_dependent
         self.pinned_directions = term_opts.pinned_directions
         self.time_interval = term_opts.time_interval

--- a/quartical/gains/leakage/kernel.py
+++ b/quartical/gains/leakage/kernel.py
@@ -73,6 +73,7 @@ def nb_leakage_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -128,6 +129,9 @@ def nb_leakage_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError("Scalar mode not supported for leakage terms.")
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/phase/kernel.py
+++ b/quartical/gains/phase/kernel.py
@@ -147,7 +147,7 @@ def nb_phase_solver_impl(
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
 
-            if scalar:
+            if scalar and corr_mode != 1:
                 scalar_jhj_jhr(native_imdry, 1)
 
             if not max_iter:  # Non-solvable term, we just want jhj.

--- a/quartical/gains/phase/kernel.py
+++ b/quartical/gains/phase/kernel.py
@@ -9,7 +9,8 @@ from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
                                               resample_solints,
-                                              downsample_jhj_jhr)
+                                              downsample_jhj_jhr,
+                                              scalar_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
@@ -88,6 +89,7 @@ def nb_phase_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -144,6 +146,9 @@ def nb_phase_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                scalar_jhj_jhr(native_imdry, 1)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/rotation/kernel.py
+++ b/quartical/gains/rotation/kernel.py
@@ -84,6 +84,7 @@ def nb_rotation_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -141,6 +142,11 @@ def nb_rotation_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError(
+                    "Scalar mode not supported for rotation terms."
+                )
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/rotation_measure/kernel.py
+++ b/quartical/gains/rotation_measure/kernel.py
@@ -84,6 +84,7 @@ def nb_rm_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -144,6 +145,11 @@ def nb_rm_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError(
+                    "Scalar mode not supported for rotation measure terms."
+                )
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/tec_and_offset/kernel.py
+++ b/quartical/gains/tec_and_offset/kernel.py
@@ -155,7 +155,7 @@ def nb_tec_and_offset_solver_impl(
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
 
-            if scalar:
+            if scalar and corr_mode != 1:
                 scalar_jhj_jhr(native_imdry, 2)
 
             if not max_iter:  # Non-solvable term, we just want jhj.

--- a/quartical/gains/tec_and_offset/kernel.py
+++ b/quartical/gains/tec_and_offset/kernel.py
@@ -9,7 +9,8 @@ from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
                                               resample_solints,
-                                              downsample_jhj_jhr)
+                                              downsample_jhj_jhr,
+                                              scalar_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
@@ -90,6 +91,7 @@ def nb_tec_and_offset_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -152,6 +154,9 @@ def nb_tec_and_offset_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                scalar_jhj_jhr(native_imdry, 2)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/testing/fixtures/gains.py
+++ b/testing/fixtures/gains.py
@@ -25,3 +25,8 @@ def cmp_post_solve_data_xds_list(cmp_calibration_graph_outputs):
 @pytest.fixture(params=["antenna", "array"], scope="module")
 def solve_per(request):
     return request.param
+
+
+@pytest.fixture(params=[True, False], scope="module")
+def scalar_mode(request):
+    return request.param

--- a/testing/tests/gains/test_amplitude.py
+++ b/testing/tests/gains/test_amplitude.py
@@ -7,7 +7,7 @@ from quartical.calibration.calibrate import add_calibration_graph
 
 
 @pytest.fixture(scope="module")
-def opts(base_opts, select_corr, solve_per):
+def opts(base_opts, select_corr, solve_per, scalar_mode):
 
     # Don't overwrite base config - instead create a copy and update.
 
@@ -22,6 +22,7 @@ def opts(base_opts, select_corr, solve_per):
     _opts.solver.threads = 2
     _opts.G.type = "amplitude"
     _opts.G.solve_per = solve_per
+    _opts.G.scalar = scalar_mode
 
     return _opts
 
@@ -33,7 +34,7 @@ def raw_xds_list(read_xds_list_output):
 
 
 @pytest.fixture(scope="module")
-def true_gain_list(predicted_xds_list, solve_per):
+def true_gain_list(predicted_xds_list, solve_per, scalar_mode):
 
     gain_list = []
 
@@ -65,6 +66,9 @@ def true_gain_list(predicted_xds_list, solve_per):
             amp *= da.array([1, 0, 0, 1])
 
         gains = amp*da.exp(1j*phase)
+
+        if scalar_mode:
+            gains[..., -1] = gains[..., 0]
 
         if solve_per == "array":
             gains = da.broadcast_to(gains[:, :, :1], gains.shape)

--- a/testing/tests/gains/test_delay_and_offset.py
+++ b/testing/tests/gains/test_delay_and_offset.py
@@ -7,7 +7,7 @@ from testing.utils.gains import apply_gains, reference_gains
 
 
 @pytest.fixture(scope="module")
-def opts(base_opts, select_corr):
+def opts(base_opts, select_corr, scalar_mode):
 
     # Don't overwrite base config - instead create a copy and update.
 
@@ -23,6 +23,7 @@ def opts(base_opts, select_corr):
     _opts.G.type = "delay_and_offset"
     _opts.G.freq_interval = 0
     _opts.G.initial_estimate = True
+    _opts.G.scalar = scalar_mode
 
     return _opts
 
@@ -34,7 +35,7 @@ def raw_xds_list(read_xds_list_output):
 
 
 @pytest.fixture(scope="module")
-def true_gain_list(predicted_xds_list):
+def true_gain_list(predicted_xds_list, scalar_mode):
 
     gain_list = []
 
@@ -81,6 +82,9 @@ def true_gain_list(predicted_xds_list):
         origin_chan_freq = origin_chan_freq[None, :, None, None, None]
         phase = 2*np.pi*delays*origin_chan_freq + offsets
         gains = amp*da.exp(1j*phase)
+
+        if scalar_mode:
+            gains[..., -1] = gains[..., 0]
 
         gain_list.append(gains)
 

--- a/testing/tests/gains/test_diag_complex.py
+++ b/testing/tests/gains/test_diag_complex.py
@@ -12,7 +12,7 @@ def solver_type(request):
 
 
 @pytest.fixture(scope="module")
-def opts(base_opts, solver_type, select_corr, solve_per):
+def opts(base_opts, solver_type, select_corr, solve_per, scalar_mode):
 
     # Don't overwrite base config - instead create a copy and update.
 
@@ -27,6 +27,7 @@ def opts(base_opts, solver_type, select_corr, solve_per):
     _opts.solver.threads = 2
     _opts.G.type = solver_type
     _opts.G.solve_per = solve_per
+    _opts.G.scalar = scalar_mode
 
     return _opts
 
@@ -38,7 +39,7 @@ def raw_xds_list(read_xds_list_output):
 
 
 @pytest.fixture(scope="module")
-def true_gain_list(predicted_xds_list, solve_per):
+def true_gain_list(predicted_xds_list, solve_per, scalar_mode):
 
     gain_list = []
 
@@ -68,6 +69,9 @@ def true_gain_list(predicted_xds_list, solve_per):
             amp *= da.array([1, 0, 0, 1])
 
         gains = amp*da.exp(1j*phase)
+
+        if scalar_mode:
+            gains[..., -1] = gains[..., 0]
 
         if solve_per == "array":
             gains = da.broadcast_to(gains[:, :, :1], gains.shape)

--- a/testing/tests/gains/test_phase.py
+++ b/testing/tests/gains/test_phase.py
@@ -7,7 +7,7 @@ from testing.utils.gains import apply_gains, reference_gains
 
 
 @pytest.fixture(scope="module")
-def opts(base_opts, select_corr, solve_per):
+def opts(base_opts, select_corr, solve_per, scalar_mode):
 
     # Don't overwrite base config - instead create a copy and update.
 
@@ -22,6 +22,7 @@ def opts(base_opts, select_corr, solve_per):
     _opts.solver.threads = 2
     _opts.G.type = "phase"
     _opts.G.solve_per = solve_per
+    _opts.G.scalar = scalar_mode
 
     return _opts
 
@@ -33,7 +34,7 @@ def raw_xds_list(read_xds_list_output):
 
 
 @pytest.fixture(scope="module")
-def true_gain_list(predicted_xds_list, solve_per):
+def true_gain_list(predicted_xds_list, solve_per, scalar_mode):
 
     gain_list = []
 
@@ -63,6 +64,9 @@ def true_gain_list(predicted_xds_list, solve_per):
             amp *= da.array([1, 0, 0, 1])
 
         gains = amp*da.exp(1j*phase)
+
+        if scalar_mode:
+            gains[..., -1] = gains[..., 0]
 
         if solve_per == "array":
             gains = da.broadcast_to(gains[:, :, :1], gains.shape)


### PR DESCRIPTION
As requested by @o-smirnov in #357. This is a slightly more general offering; diagonal parameterised Jones terms now support a support a scalar mode where appropriate. This is enabled by setting `term.scalar=true` where `term` is the name of any specified gain term.

At present, the scalar mode is not supported for `diag_complex` terms. This is because the solver is a little different for the diagonal complex case and the generic approach I have taken in this PR won't work.  

Edit: I have added support for scalar `diag_complex` terms.