### PR TITLE
Add a workaround for selection in the presence of partial columns

### DIFF
--- a/quartical/data_handling/angles.py
+++ b/quartical/data_handling/angles.py
@@ -107,6 +107,8 @@ def make_parangle_xds_list(ms_path, data_xds_list):
 
     for xds, field_centre in zip(data_xds_list, field_centres):
 
+        # TODO: This is unnecessary - we should just reify the field centres
+        # and pass them in.
         cloned_field_centre = da.concatenate(
             [clone(field_centre) for _ in xds.chunksizes["row"]]
         )

--- a/quartical/data_handling/angles.py
+++ b/quartical/data_handling/angles.py
@@ -107,12 +107,16 @@ def make_parangle_xds_list(ms_path, data_xds_list):
 
     for xds, field_centre in zip(data_xds_list, field_centres):
 
+        cloned_field_centre = da.concatenate(
+            [clone(field_centre) for _ in xds.chunksizes["row"]]
+        )
+
         parangles = da.blockwise(_make_parangles, "tar",
                                  xds.TIME.data, "t",
                                  clone(ant_names), "a",
                                  clone(ant_positions_ecef), "a3",
                                  clone(receptor_angles), "ar",
-                                 clone(field_centre), "t",
+                                 cloned_field_centre, "t",
                                  epoch, None,
                                  align_arrays=False,
                                  concatenate=True,


### PR DESCRIPTION
Fixes #226 and is related to #363. At present, due to the manner in which datasets are opened with `xds_from_table` and its variants, the code was checking for the presence of columns on deselected datasets. This PR is the simple solution, but a more comprehensive refactoring is required.