### PR TITLE
Update delay/TEC parameterisation to use global frequency information

### DIFF
--- a/quartical/calibration/constructor.py
+++ b/quartical/calibration/constructor.py
@@ -72,6 +72,11 @@ def construct_solver(
             if v.name in required_fields:
                 blocker.add_input(v.name, v.data, v.dims)
 
+        # If a required value is in the xds attrs, add it to the blocker.
+        for k, v in data_xds.attrs.items():
+            if k in required_fields:
+                blocker.add_input(k, v)
+
         # NOTE: We need to treat time as a rowlike dimension here.
         for v in mapping_xds.data_vars.values():
             blocker.add_input(

--- a/quartical/data_handling/ms_handler.py
+++ b/quartical/data_handling/ms_handler.py
@@ -138,9 +138,8 @@ def read_xds_list(model_columns, ms_opts):
 
     for spw_xds in spw_xds_list:
         chan_freq = spw_xds.CHAN_FREQ.values  # Reify.
-        min_freq, max_freq = chan_freq.min(), chan_freq.max()
-        spw_xds.attrs["CENTRAL_FREQ"] = (min_freq + max_freq) / 2
-        spw_xds.attrs["BANDWIDTH"] = max_freq - min_freq
+        spw_xds.attrs["MIN_FREQ"] = chan_freq.min()
+        spw_xds.attrs["MAX_FREQ"] = chan_freq.max()
 
     # Preserve a copy of the xds_list prior to any BDA/assignment. Necessary
     # for undoing BDA.
@@ -173,8 +172,6 @@ def read_xds_list(model_columns, ms_opts):
         spw_xds = spw_xds_list[xds.DATA_DESC_ID]
         chan_freqs = clone(spw_xds.CHAN_FREQ.data)
         chan_widths = clone(spw_xds.CHAN_WIDTH.data)
-        bandwidth = spw_xds.attrs["BANDWIDTH"]
-        central_freq = spw_xds.attrs["CENTRAL_FREQ"]
 
         _xds = _xds.assign(
             {
@@ -196,8 +193,8 @@ def read_xds_list(model_columns, ms_opts):
             {
                 "UTIME_CHUNKS": utime_chunks,
                 "FIELD_NAME": field_name,
-                "BANDWIDTH": bandwidth,
-                "CENTRAL_FREQ": central_freq
+                "MIN_FREQ": spw_xds.MIN_FREQ,
+                "MAX_FREQ": spw_xds.MAX_FREQ
             }
         )
 

--- a/quartical/gains/delay/__init__.py
+++ b/quartical/gains/delay/__init__.py
@@ -15,7 +15,8 @@ from quartical.gains.general.flagging import (
 ms_inputs = namedtuple(
     'ms_inputs', ParameterizedGain.ms_inputs._fields + (
         'CHAN_FREQ',
-        'CENTRAL_FREQ'
+        'MIN_FREQ',
+        'MAX_FREQ'
     )
 )
 
@@ -67,7 +68,8 @@ class Delay(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
-            ms_kwargs["CENTRAL_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 
@@ -166,7 +168,8 @@ class Delay(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
-            ms_kwargs["CENTRAL_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 

--- a/quartical/gains/delay/__init__.py
+++ b/quartical/gains/delay/__init__.py
@@ -13,7 +13,10 @@ from quartical.gains.general.flagging import (
 
 # Overload the default measurement set inputs to include the frequencies.
 ms_inputs = namedtuple(
-    'ms_inputs', ParameterizedGain.ms_inputs._fields + ('CHAN_FREQ',)
+    'ms_inputs', ParameterizedGain.ms_inputs._fields + (
+        'CHAN_FREQ',
+        'CENTRAL_FREQ'
+    )
 )
 
 
@@ -64,6 +67,7 @@ class Delay(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["CENTRAL_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 
@@ -162,6 +166,7 @@ class Delay(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["CENTRAL_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -137,8 +137,7 @@ def nb_delay_solver_impl(
 
         # We actually solve for D' = (D(nu_min + nu_max))/2. This helps avoid
         # numerical issues, but requires some scaling of the parameters.
-        chan_freq = ms_inputs.CHAN_FREQ
-        mid_freq = (chan_freq.min() + chan_freq.max())/2
+        mid_freq = ms_inputs.CENTRAL_FREQ
         active_params[:] *= mid_freq
 
         for loop_idx in range(max_iter or 1):
@@ -330,9 +329,7 @@ def nb_compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        cf_min = chan_freq.min()
-        cf_max = chan_freq.max()
-        cf_mid = (cf_min + cf_max) / 2
+        cf_mid = ms_inputs.CENTRAL_FREQ
 
         # Determine loop variables based on where we are in the chain.
         # gt means greater than (n>j) and lt means less than (n<j).
@@ -601,9 +598,7 @@ def nb_finalize_update(
                     params[..., pd, :] = 0
 
             chan_freq = ms_inputs.CHAN_FREQ
-            cf_min = chan_freq.min()
-            cf_max = chan_freq.max()
-            cf_mid = (cf_min + cf_max) / 2
+            cf_mid = ms_inputs.CENTRAL_FREQ
 
             for t in range(n_time):
                 for f in range(n_freq):
@@ -793,15 +788,14 @@ def delay_params_to_gains(
     params,
     gains,
     chan_freq,
+    central_freq,
     param_freq_map,
     rescaled=False
 ):
 
     n_time, n_freq, n_ant, n_dir, n_corr = gains.shape
 
-    cf_min = chan_freq.min()
-    cf_max = chan_freq.max()
-    cf_mid = (cf_min + cf_max) / 2
+    cf_mid = central_freq
 
     if rescaled:
         offset = 1.0
@@ -830,6 +824,7 @@ def delay_params_to_gains(
 def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
 
     chan_freq = ms_inputs.CHAN_FREQ
+    central_freq = ms_inputs.CENTRAL_FREQ
 
     active_term = meta_inputs.active_term
     ref_ant = meta_inputs.reference_antenna
@@ -859,7 +854,12 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
                         p -= rp
 
     delay_params_to_gains(
-        params, gains, chan_freq, param_freq_map, rescaled=True
+        params,
+        gains,
+        chan_freq,
+        central_freq,
+        param_freq_map,
+        rescaled=True
     )
 
     # Referencing may move flagged gains/params from identity.

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -137,7 +137,7 @@ def nb_delay_solver_impl(
 
         # We actually solve for D' = (D(nu_min + nu_max))/2. This helps avoid
         # numerical issues, but requires some scaling of the parameters.
-        mid_freq = ms_inputs.CENTRAL_FREQ
+        mid_freq = (ms_inputs.MIN_FREQ + ms_inputs.MAX_FREQ) / 2
         active_params[:] *= mid_freq
 
         for loop_idx in range(max_iter or 1):
@@ -329,7 +329,7 @@ def nb_compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        cf_mid = ms_inputs.CENTRAL_FREQ
+        cf_mid = (ms_inputs.MIN_FREQ + ms_inputs.MAX_FREQ) / 2
 
         # Determine loop variables based on where we are in the chain.
         # gt means greater than (n>j) and lt means less than (n<j).
@@ -598,7 +598,7 @@ def nb_finalize_update(
                     params[..., pd, :] = 0
 
             chan_freq = ms_inputs.CHAN_FREQ
-            cf_mid = ms_inputs.CENTRAL_FREQ
+            cf_mid = (ms_inputs.MIN_FREQ + ms_inputs.MAX_FREQ) / 2
 
             for t in range(n_time):
                 for f in range(n_freq):
@@ -788,14 +788,15 @@ def delay_params_to_gains(
     params,
     gains,
     chan_freq,
-    central_freq,
+    min_freq,
+    max_freq,
     param_freq_map,
     rescaled=False
 ):
 
     n_time, n_freq, n_ant, n_dir, n_corr = gains.shape
 
-    cf_mid = central_freq
+    cf_mid = (min_freq + max_freq) / 2
 
     if rescaled:
         offset = 1.0
@@ -824,7 +825,6 @@ def delay_params_to_gains(
 def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
 
     chan_freq = ms_inputs.CHAN_FREQ
-    central_freq = ms_inputs.CENTRAL_FREQ
 
     active_term = meta_inputs.active_term
     ref_ant = meta_inputs.reference_antenna
@@ -857,7 +857,8 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
         params,
         gains,
         chan_freq,
-        central_freq,
+        ms_inputs.MIN_FREQ,
+        ms_inputs.MAX_FREQ,
         param_freq_map,
         rescaled=True
     )

--- a/quartical/gains/delay_and_offset/__init__.py
+++ b/quartical/gains/delay_and_offset/__init__.py
@@ -13,7 +13,10 @@ from quartical.gains.general.flagging import (
 
 # Overload the default measurement set inputs to include the frequencies.
 ms_inputs = namedtuple(
-    'ms_inputs', ParameterizedGain.ms_inputs._fields + ('CHAN_FREQ',)
+    'ms_inputs', ParameterizedGain.ms_inputs._fields + (
+        'CHAN_FREQ',
+        'CENTRAL_FREQ'
+    )
 )
 
 
@@ -67,6 +70,7 @@ class DelayAndOffset(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["CENTRAL_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 
@@ -165,6 +169,7 @@ class DelayAndOffset(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["CENTRAL_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 

--- a/quartical/gains/delay_and_offset/__init__.py
+++ b/quartical/gains/delay_and_offset/__init__.py
@@ -15,7 +15,8 @@ from quartical.gains.general.flagging import (
 ms_inputs = namedtuple(
     'ms_inputs', ParameterizedGain.ms_inputs._fields + (
         'CHAN_FREQ',
-        'CENTRAL_FREQ'
+        'MIN_FREQ',
+        'MAX_FREQ'
     )
 )
 
@@ -70,7 +71,8 @@ class DelayAndOffset(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
-            ms_kwargs["CENTRAL_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 
@@ -169,7 +171,8 @@ class DelayAndOffset(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
-            ms_kwargs["CENTRAL_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 

--- a/quartical/gains/delay_and_offset/kernel.py
+++ b/quartical/gains/delay_and_offset/kernel.py
@@ -138,7 +138,7 @@ def nb_delay_and_offset_solver_impl(
 
         # We actually solve for D' = (D(nu_min + nu_max))/2. This helps avoid
         # numerical issues, but requires some scaling of the parameters.
-        mid_freq = ms_inputs.CENTRAL_FREQ
+        mid_freq = (ms_inputs.MIN_FREQ + ms_inputs.MAX_FREQ) / 2
         active_params[..., 1::2] *= mid_freq
 
         for loop_idx in range(max_iter or 1):
@@ -330,7 +330,7 @@ def nb_compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        cf_mid = ms_inputs.CENTRAL_FREQ
+        cf_mid = (ms_inputs.MIN_FREQ + ms_inputs.MAX_FREQ) / 2
 
         # Determine loop variables based on where we are in the chain.
         # gt means greater than (n>j) and lt means less than (n<j).
@@ -599,7 +599,7 @@ def nb_finalize_update(
                     params[..., pd, :] = 0
 
             chan_freq = ms_inputs.CHAN_FREQ
-            cf_mid = ms_inputs.CENTRAL_FREQ
+            cf_mid = (ms_inputs.MIN_FREQ + ms_inputs.MAX_FREQ) / 2
 
             for t in range(n_time):
                 for f in range(n_freq):
@@ -828,14 +828,15 @@ def delay_and_offset_params_to_gains(
     params,
     gains,
     chan_freq,
-    central_freq,
+    min_freq,
+    max_freq,
     param_freq_map,
     rescaled=False
 ):
 
     n_time, n_freq, n_ant, n_dir, n_corr = gains.shape
 
-    cf_mid = central_freq
+    cf_mid = (min_freq + max_freq) / 2
 
     if rescaled:
         offset = 1.0
@@ -864,7 +865,6 @@ def delay_and_offset_params_to_gains(
 def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
 
     chan_freq = ms_inputs.CHAN_FREQ
-    central_freq = ms_inputs.CENTRAL_FREQ
 
     active_term = meta_inputs.active_term
     ref_ant = meta_inputs.reference_antenna
@@ -897,7 +897,8 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
         params,
         gains,
         chan_freq,
-        central_freq,
+        ms_inputs.MIN_FREQ,
+        ms_inputs.MAX_FREQ,
         param_freq_map,
         rescaled=True
     )

--- a/quartical/gains/delay_and_offset/kernel.py
+++ b/quartical/gains/delay_and_offset/kernel.py
@@ -138,8 +138,7 @@ def nb_delay_and_offset_solver_impl(
 
         # We actually solve for D' = (D(nu_min + nu_max))/2. This helps avoid
         # numerical issues, but requires some scaling of the parameters.
-        chan_freq = ms_inputs.CHAN_FREQ
-        mid_freq = (chan_freq.min() + chan_freq.max())/2
+        mid_freq = ms_inputs.CENTRAL_FREQ
         active_params[..., 1::2] *= mid_freq
 
         for loop_idx in range(max_iter or 1):
@@ -331,9 +330,7 @@ def nb_compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        cf_min = chan_freq.min()
-        cf_max = chan_freq.max()
-        cf_mid = (cf_min + cf_max) / 2
+        cf_mid = ms_inputs.CENTRAL_FREQ
 
         # Determine loop variables based on where we are in the chain.
         # gt means greater than (n>j) and lt means less than (n<j).
@@ -602,9 +599,7 @@ def nb_finalize_update(
                     params[..., pd, :] = 0
 
             chan_freq = ms_inputs.CHAN_FREQ
-            cf_min = chan_freq.min()
-            cf_max = chan_freq.max()
-            cf_mid = (cf_min + cf_max) / 2
+            cf_mid = ms_inputs.CENTRAL_FREQ
 
             for t in range(n_time):
                 for f in range(n_freq):
@@ -833,15 +828,14 @@ def delay_and_offset_params_to_gains(
     params,
     gains,
     chan_freq,
+    central_freq,
     param_freq_map,
     rescaled=False
 ):
 
     n_time, n_freq, n_ant, n_dir, n_corr = gains.shape
 
-    cf_min = chan_freq.min()
-    cf_max = chan_freq.max()
-    cf_mid = (cf_min + cf_max) / 2
+    cf_mid = central_freq
 
     if rescaled:
         offset = 1.0
@@ -870,6 +864,7 @@ def delay_and_offset_params_to_gains(
 def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
 
     chan_freq = ms_inputs.CHAN_FREQ
+    central_freq = ms_inputs.CENTRAL_FREQ
 
     active_term = meta_inputs.active_term
     ref_ant = meta_inputs.reference_antenna
@@ -899,7 +894,12 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
                         p -= rp
 
     delay_and_offset_params_to_gains(
-        params, gains, chan_freq, param_freq_map, rescaled=True
+        params,
+        gains,
+        chan_freq,
+        central_freq,
+        param_freq_map,
+        rescaled=True
     )
 
     # Referencing may move flagged gains/params from identity.

--- a/quartical/gains/delay_and_tec/__init__.py
+++ b/quartical/gains/delay_and_tec/__init__.py
@@ -13,7 +13,11 @@ from quartical.gains.general.flagging import (
 
 # Overload the default measurement set inputs to include the frequencies.
 ms_inputs = namedtuple(
-    'ms_inputs', ParameterizedGain.ms_inputs._fields + ('CHAN_FREQ',)
+    'ms_inputs', ParameterizedGain.ms_inputs._fields + (
+        'CHAN_FREQ',
+        'MIN_FREQ',
+        'MAX_FREQ'
+    )
 )
 
 
@@ -66,6 +70,8 @@ class DelayAndTec(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 
@@ -164,6 +170,8 @@ class DelayAndTec(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 

--- a/quartical/gains/tec_and_offset/__init__.py
+++ b/quartical/gains/tec_and_offset/__init__.py
@@ -13,7 +13,11 @@ from quartical.gains.general.flagging import (
 
 # Overload the default measurement set inputs to include the frequencies.
 ms_inputs = namedtuple(
-    'ms_inputs', ParameterizedGain.ms_inputs._fields + ('CHAN_FREQ',)
+    'ms_inputs', ParameterizedGain.ms_inputs._fields + (
+        'CHAN_FREQ',
+        'MIN_FREQ',
+        'MAX_FREQ'
+    )
 )
 
 
@@ -67,6 +71,8 @@ class TecAndOffset(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 

--- a/quartical/gains/tec_and_offset/kernel.py
+++ b/quartical/gains/tec_and_offset/kernel.py
@@ -133,8 +133,7 @@ def nb_tec_and_offset_solver_impl(
 
         # We actually solve for TEC' = TEC/bandwidth. This helps avoid
         # numerical issues, but requires some scaling of the parameters.
-        chan_freq = ms_inputs.CHAN_FREQ
-        bandwidth = chan_freq.max() - chan_freq.min()
+        bandwidth = ms_inputs.MAX_FREQ - ms_inputs.MIN_FREQ
         active_params[..., 1::2] /= bandwidth
 
         for loop_idx in range(max_iter or 1):
@@ -326,8 +325,8 @@ def nb_compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        cf_min = chan_freq.min()
-        cf_max = chan_freq.max()
+        cf_min = ms_inputs.MIN_FREQ
+        cf_max = ms_inputs.MAX_FREQ
         bandwidth = cf_max - cf_min
         offset = np.log(cf_min / cf_max)
 
@@ -598,8 +597,8 @@ def nb_finalize_update(
                     params[..., pd, :] = 0
 
             chan_freq = ms_inputs.CHAN_FREQ
-            cf_min = chan_freq.min()
-            cf_max = chan_freq.max()
+            cf_min = ms_inputs.MIN_FREQ
+            cf_max = ms_inputs.MAX_FREQ
             bandwidth = cf_max - cf_min
             offset = np.log(cf_min/cf_max)
 
@@ -830,14 +829,16 @@ def tec_and_offset_params_to_gains(
     params,
     gains,
     chan_freq,
+    min_freq,
+    max_freq,
     param_freq_map,
     rescaled=False
 ):
 
     n_time, n_freq, n_ant, n_dir, n_corr = gains.shape
 
-    cf_min = chan_freq.min()
-    cf_max = chan_freq.max()
+    cf_min = min_freq
+    cf_max = max_freq
     bandwidth = cf_max - cf_min
 
     # The log term absorbs the leading factor of -1, inverting the fraction.
@@ -897,7 +898,13 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
                         p -= rp
 
     tec_and_offset_params_to_gains(
-        params, gains, chan_freq, param_freq_map, rescaled=True
+        params,
+        gains,
+        chan_freq,
+        ms_inputs.MIN_FREQ,
+        ms_inputs.MAX_FREQ,
+        param_freq_map,
+        rescaled=True
     )
 
     # Referencing may move flagged gains/params from identity.


### PR DESCRIPTION
This PR is the first step in correcting for a subtle error discussed in #366. This does not fix the (unusual) case where multiple delay/TEC terms are solved along the frequency axis. Instead, this resolves the more common problem which was occurring when loading a delay/TEC term from disk with different chunking. This resulted in a change in the minimum and maximum frequencies in each chunk which in turn altered the parameterisation. All the delay/TEC terms now use the global minimum and maximum frequencies (in each SPW) in their parameterisation to avoid this problem.