### PR TITLE
Optionally initialise the crosshand phases from the XY-phase

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:

--- a/quartical/calibration/constructor.py
+++ b/quartical/calibration/constructor.py
@@ -72,6 +72,11 @@ def construct_solver(
             if v.name in required_fields:
                 blocker.add_input(v.name, v.data, v.dims)
 
+        # If a required value is in the xds attrs, add it to the blocker.
+        for k, v in data_xds.attrs.items():
+            if k in required_fields:
+                blocker.add_input(k, v)
+
         # NOTE: We need to treat time as a rowlike dimension here.
         for v in mapping_xds.data_vars.values():
             blocker.add_input(

--- a/quartical/calibration/solver.py
+++ b/quartical/calibration/solver.py
@@ -229,7 +229,8 @@ def solver_wrapper(
                 corr_mode
             )
         else:
-            jhj = np.zeros(getattr(active_spec, "pshape", active_spec.shape))
+            pshape, gshape = active_spec.pshape, active_spec.shape
+            jhj = np.zeros(pshape if term.is_parameterized else gshape)
             conv_iter, conv_perc = 0, 1
 
         # If reweighting is enabled, do it when the epoch changes, except

--- a/quartical/calibration/solver.py
+++ b/quartical/calibration/solver.py
@@ -19,6 +19,7 @@ meta_args_nt = namedtuple(
         "threads",
         "robust",
         "reference_antenna",
+        "scalar",
         "dd_term",
         "pinned_directions",
         "solve_per",
@@ -233,6 +234,7 @@ def solver_wrapper(
             solver_opts.threads,
             solver_opts.robust,
             solver_opts.reference_antenna,
+            term.scalar,
             term.direction_dependent,
             term.pinned_directions,
             term.solve_per

--- a/quartical/config/argument_schema.yaml
+++ b/quartical/config/argument_schema.yaml
@@ -357,6 +357,16 @@ solver:
       almost always be enabled so that data associated with diverging gains
       is properly flagged.
 
+  collapse_chain:
+    dtype: bool
+    default: True
+    info:
+      Determines whether the chain is collapsed into the minimum number of
+      terms inside the solver. This will typically increase memory footprint,
+      but may speed up calibration when utilising many gain terms. Set to false
+      to apply every term on-the-fly inside the solver (behaviour prior to
+      v0.2.6).
+
   robust:
     dtype: bool
     default: False

--- a/quartical/config/gain_schema.yaml
+++ b/quartical/config/gain_schema.yaml
@@ -29,9 +29,17 @@ gain:
       Determines whether this term should be solved per antenna (conventional)
       or over the entire array (doesn't vary with antenna).
 
+  scalar:
+    dtype: bool
+    default: false
+    info:
+      Determines whether the term is treated as scalar i.e. whether it is
+      solved for as a single effect over all correlations. This is only
+      supported for terms which would otherwise be diagonal.
+
   direction_dependent:
     dtype: bool
-    default: False
+    default: false
     info:
       Determines whether this term is treated as direction dependent.
 

--- a/quartical/config/gain_schema.yaml
+++ b/quartical/config/gain_schema.yaml
@@ -17,6 +17,7 @@ gain:
       - crosshand_phase_null_v
       - leakage
       - parallactic_angle
+      - feed_flip
     info:
       Type of gain to solve for.
 

--- a/quartical/config/helper.py
+++ b/quartical/config/helper.py
@@ -70,7 +70,9 @@ def print_help(HelpConfig, section_names=None):
 def help():
     """Prints the help."""
 
-    help_args = [arg for arg in sys.argv if arg.startswith('help')]
+    # NOTE: If evert we have an argument which starts with help, this might
+    # cause a problem. Ok for now.
+    help_args = [arg for arg in sys.argv if arg.lstrip('-').startswith('help')]
 
     # Always take the last specified help request.
     help_arg = help_args.pop() if help_args else help_args

--- a/quartical/config/helper.py
+++ b/quartical/config/helper.py
@@ -88,7 +88,7 @@ def help():
         print_help(HelpConfig)
     else:
         selection = help_arg.split("=")[-1]
-        selection = re.sub('[\[\] ]', "", selection)  # noqa
+        selection = re.sub(r'[\[\] ]', "", selection)
         selection = selection.split(",")
         print_help(HelpConfig, section_names=selection)
 

--- a/quartical/config/parser.py
+++ b/quartical/config/parser.py
@@ -2,7 +2,7 @@
 import sys
 import os
 from loguru import logger
-from ruamel.yaml import round_trip_dump
+from ruamel.yaml import YAML
 from omegaconf import OmegaConf as oc
 from quartical.config.external import finalize_structure
 from quartical.config.internal import additional_validation
@@ -26,13 +26,9 @@ def create_user_config():
     config = oc.merge(config, *additional_config)
 
     with open(config_file_path, 'w') as outfile:
-        round_trip_dump(
-            oc.to_container(config),
-            outfile,
-            default_flow_style=False,
-            width=60,
-            indent=2
-        )
+        yaml = YAML()
+
+        yaml.dump(oc.to_container(config), outfile)
 
     logger.success(
         f"{config_file_path} successfully generated. Go forth and calibrate!"

--- a/quartical/data_handling/angles.py
+++ b/quartical/data_handling/angles.py
@@ -107,12 +107,18 @@ def make_parangle_xds_list(ms_path, data_xds_list):
 
     for xds, field_centre in zip(data_xds_list, field_centres):
 
+        # TODO: This is unnecessary - we should just reify the field centres
+        # and pass them in.
+        cloned_field_centre = da.concatenate(
+            [clone(field_centre) for _ in xds.chunksizes["row"]]
+        )
+
         parangles = da.blockwise(_make_parangles, "tar",
                                  xds.TIME.data, "t",
                                  clone(ant_names), "a",
                                  clone(ant_positions_ecef), "a3",
                                  clone(receptor_angles), "ar",
-                                 clone(field_centre), "t",
+                                 cloned_field_centre, "t",
                                  epoch, None,
                                  align_arrays=False,
                                  concatenate=True,

--- a/quartical/data_handling/ms_handler.py
+++ b/quartical/data_handling/ms_handler.py
@@ -136,6 +136,11 @@ def read_xds_list(model_columns, ms_opts):
         chunks=chunking_per_spw_xds
     )
 
+    for spw_xds in spw_xds_list:
+        chan_freq = spw_xds.CHAN_FREQ.values  # Reify.
+        spw_xds.attrs["MIN_FREQ"] = chan_freq.min()
+        spw_xds.attrs["MAX_FREQ"] = chan_freq.max()
+
     # Preserve a copy of the xds_list prior to any BDA/assignment. Necessary
     # for undoing BDA.
     ref_xds_list = data_xds_list if ms_opts.is_bda else None
@@ -164,8 +169,9 @@ def read_xds_list(model_columns, ms_opts):
         # for solvers which require this information. Also adds the antenna
         # names which will be useful when reference antennas are required.
 
-        chan_freqs = clone(spw_xds_list[xds.DATA_DESC_ID].CHAN_FREQ.data)
-        chan_widths = clone(spw_xds_list[xds.DATA_DESC_ID].CHAN_WIDTH.data)
+        spw_xds = spw_xds_list[xds.DATA_DESC_ID]
+        chan_freqs = clone(spw_xds.CHAN_FREQ.data)
+        chan_widths = clone(spw_xds.CHAN_WIDTH.data)
 
         _xds = _xds.assign(
             {
@@ -186,7 +192,9 @@ def read_xds_list(model_columns, ms_opts):
         _xds = _xds.assign_attrs(
             {
                 "UTIME_CHUNKS": utime_chunks,
-                "FIELD_NAME": field_name
+                "FIELD_NAME": field_name,
+                "MIN_FREQ": spw_xds.MIN_FREQ,
+                "MAX_FREQ": spw_xds.MAX_FREQ
             }
         )
 

--- a/quartical/gains/__init__.py
+++ b/quartical/gains/__init__.py
@@ -10,6 +10,7 @@ from quartical.gains.crosshand_phase import CrosshandPhase, CrosshandPhaseNullV
 from quartical.gains.leakage import Leakage
 from quartical.gains.delay_and_tec import DelayAndTec
 from quartical.gains.parallactic_angle import ParallacticAngle
+from quartical.gains.feed_flip import FeedFlip
 
 
 TERM_TYPES = {
@@ -26,5 +27,6 @@ TERM_TYPES = {
     "crosshand_phase_null_v": CrosshandPhaseNullV,
     "leakage": Leakage,
     "delay_and_tec": DelayAndTec,
-    "parallactic_angle": ParallacticAngle
+    "parallactic_angle": ParallacticAngle,
+    "feed_flip": FeedFlip
 }

--- a/quartical/gains/amplitude/kernel.py
+++ b/quartical/gains/amplitude/kernel.py
@@ -9,7 +9,8 @@ from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
                                               resample_solints,
-                                              downsample_jhj_jhr)
+                                              downsample_jhj_jhr,
+                                              scalar_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
@@ -86,6 +87,7 @@ def nb_amplitude_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -143,6 +145,9 @@ def nb_amplitude_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar and corr_mode != 1:
+                scalar_jhj_jhr(native_imdry, 1)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/complex/diag_kernel.py
+++ b/quartical/gains/complex/diag_kernel.py
@@ -74,6 +74,7 @@ def nb_diag_complex_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -128,6 +129,9 @@ def nb_diag_complex_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar and corr_mode != 1:
+                scalar_jhj_jhr(native_imdry)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.
@@ -677,3 +681,34 @@ def nb_reference_gains_impl(chain_inputs, meta_inputs, mode):
         apply_gain_flags_to_gains(gain_flags, gains)
 
     return impl
+
+
+@njit(**JIT_OPTIONS)
+def scalar_jhj_jhr(solver_imdry):
+    """This manipulates the entries of jhj and jhr to be scalar."""
+
+    # NOTE: This differes from the generic implmenentation in generics.py.
+
+    jhj = solver_imdry.jhj
+    jhr = solver_imdry.jhr
+
+    n_tint, n_fint, n_ant, n_dir, n_corr = jhj.shape
+
+    for t in range(n_tint):
+        for f in range(n_fint):
+            for a in range(n_ant):
+                for d in range(n_dir):
+
+                    jhr_sel = jhr[t, f, a, d]
+                    jhj_sel = jhj[t, f, a, d]
+
+                    # Sum to a single scalar element.
+                    for p in range(1, n_corr):
+                        jhr_sel[0] += jhr_sel[p]
+                        jhr_sel[p] = 0
+                        jhj_sel[0] += jhj_sel[p]
+                        jhj_sel[p] = 0
+
+                    # Repopluate appropriate zeroed values from scalar sum.
+                    jhr_sel[-1] = jhr_sel[0]
+                    jhj_sel[-1] = jhj_sel[0]

--- a/quartical/gains/complex/kernel.py
+++ b/quartical/gains/complex/kernel.py
@@ -75,6 +75,7 @@ def nb_complex_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -131,6 +132,9 @@ def nb_complex_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError("Scalar mode not supported for complex terms.")
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/crosshand_phase/__init__.py
+++ b/quartical/gains/crosshand_phase/__init__.py
@@ -66,6 +66,13 @@ class CrosshandPhase(ParameterizedGain):
 
         # We only need the autocorrelations.
         sel = np.where(a1 == a2)
+
+        if not (sel[0].ndim and sel[0].size):
+            raise ValueError(
+                "No autocorrelations present in the data. These are required "
+                "for performing initial estimates for the crosshand phase."
+            )
+
         a1 = a1[sel]
         a2 = a2[sel]
         t_map = t_map[sel]

--- a/quartical/gains/crosshand_phase/__init__.py
+++ b/quartical/gains/crosshand_phase/__init__.py
@@ -3,7 +3,8 @@ from quartical.gains.conversion import trig_to_angle
 from quartical.gains.parameterized_gain import ParameterizedGain
 from quartical.gains.crosshand_phase.kernel import (
     crosshand_phase_solver,
-    crosshand_params_to_gains
+    crosshand_params_to_gains,
+    get_mean_xy_phase
 )
 from quartical.gains.crosshand_phase.null_v_kernel import (
     null_v_crosshand_phase_solver
@@ -48,6 +49,35 @@ class CrosshandPhase(ParameterizedGain):
         gains, gain_flags, params, param_flags = super().init_term(
             term_spec, ref_ant, ms_kwargs, term_kwargs
         )
+
+        if self.load_from or not self.initial_estimate:
+
+            apply_param_flags_to_params(param_flags, params, 0)
+            apply_gain_flags_to_gains(gain_flags, gains)
+
+            return gains, gain_flags, params, param_flags
+
+        data = ms_kwargs["DATA"]  # (row, chan, corr)
+        flags = ms_kwargs["FLAG"]  # (row, chan)
+        a1 = ms_kwargs["ANTENNA1"]
+        a2 = ms_kwargs["ANTENNA2"]
+        t_map = term_kwargs[f"{term_spec.name}_time_map"]
+        f_map = term_kwargs[f"{term_spec.name}_param_freq_map"]
+
+        # We only need the autocorrelations.
+        sel = np.where(a1 == a2)
+        a1 = a1[sel]
+        a2 = a2[sel]
+        t_map = t_map[sel]
+        data = data[sel]
+        flags = flags[sel]
+
+        params[...] = np.angle(get_mean_xy_phase(data, t_map, f_map, a1))
+
+        # NOTE(JSKenyon): This is a hack for now - ideally, we would be able to
+        # trust the flags on the autos when doing this.
+        gain_flags[...] = 0
+        param_flags[...] = 0
 
         # Convert the parameters into gains.
         crosshand_params_to_gains(params, gains)

--- a/quartical/gains/crosshand_phase/kernel.py
+++ b/quartical/gains/crosshand_phase/kernel.py
@@ -84,6 +84,7 @@ def nb_crosshand_phase_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -140,6 +141,11 @@ def nb_crosshand_phase_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError(
+                    "Scalar mode not supported for crosshand phase terms."
+                )
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/crosshand_phase/kernel.py
+++ b/quartical/gains/crosshand_phase/kernel.py
@@ -665,3 +665,33 @@ def crosshand_params_to_gains(
 
                     g[0] = np.exp(1j*p[0])
                     g[-1] = 1
+
+
+@njit(**JIT_OPTIONS)
+def get_mean_xy_phase(
+    vis,
+    t_map,
+    f_map,
+    antenna,
+):
+
+    n_row, n_chan, n_corr = vis.shape
+
+    n_tint = t_map.max() + 1
+    n_fint = f_map.max() + 1
+    n_ant = antenna.max() + 1
+
+    output = np.zeros((n_tint, n_fint, n_ant, 1, 1), dtype=np.complex64)
+    counts = np.zeros((n_tint, n_fint, n_ant, 1, 1))
+
+    for r in range(n_row):
+        for c in range(n_chan):
+
+            ti = t_map[r]
+            fi = f_map[c]
+            ant = antenna[r]
+
+            output[ti, fi, ant, 0, 0] = vis[r, c, 1]
+            counts[ti, fi, ant, 0, 0] += 1
+
+    return output/counts

--- a/quartical/gains/crosshand_phase/kernel.py
+++ b/quartical/gains/crosshand_phase/kernel.py
@@ -668,7 +668,7 @@ def crosshand_params_to_gains(
 
 
 @njit(**JIT_OPTIONS)
-def get_mean_xy_phase(
+def get_xy_sum_and_counts(
     vis,
     t_map,
     f_map,
@@ -694,4 +694,4 @@ def get_mean_xy_phase(
             output[ti, fi, ant, 0, 0] = vis[r, c, 1]
             counts[ti, fi, ant, 0, 0] += 1
 
-    return output/counts
+    return output, counts

--- a/quartical/gains/crosshand_phase/null_v_kernel.py
+++ b/quartical/gains/crosshand_phase/null_v_kernel.py
@@ -91,6 +91,7 @@ def nb_null_v_crosshand_phase_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -148,6 +149,11 @@ def nb_null_v_crosshand_phase_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError(
+                    "Scalar mode not supported for crosshand phase terms."
+                )
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/delay/__init__.py
+++ b/quartical/gains/delay/__init__.py
@@ -13,7 +13,11 @@ from quartical.gains.general.flagging import (
 
 # Overload the default measurement set inputs to include the frequencies.
 ms_inputs = namedtuple(
-    'ms_inputs', ParameterizedGain.ms_inputs._fields + ('CHAN_FREQ',)
+    'ms_inputs', ParameterizedGain.ms_inputs._fields + (
+        'CHAN_FREQ',
+        'MIN_FREQ',
+        'MAX_FREQ'
+    )
 )
 
 
@@ -64,6 +68,8 @@ class Delay(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 
@@ -162,6 +168,8 @@ class Delay(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -12,7 +12,8 @@ from quartical.gains.general.generics import (
     upsampled_itermediaries,
     per_array_jhj_jhr,
     resample_solints,
-    downsample_jhj_jhr
+    downsample_jhj_jhr,
+    scalar_jhj_jhr
 )
 from quartical.gains.general.flagging import (
     flag_intermediaries,
@@ -94,6 +95,7 @@ def nb_delay_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -156,6 +158,9 @@ def nb_delay_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar and corr_mode != 1:
+                scalar_jhj_jhr(native_imdry, 1)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/delay/kernel.py
+++ b/quartical/gains/delay/kernel.py
@@ -137,8 +137,7 @@ def nb_delay_solver_impl(
 
         # We actually solve for D' = (D(nu_min + nu_max))/2. This helps avoid
         # numerical issues, but requires some scaling of the parameters.
-        chan_freq = ms_inputs.CHAN_FREQ
-        mid_freq = (chan_freq.min() + chan_freq.max())/2
+        mid_freq = (ms_inputs.MIN_FREQ + ms_inputs.MAX_FREQ) / 2
         active_params[:] *= mid_freq
 
         for loop_idx in range(max_iter or 1):
@@ -330,9 +329,7 @@ def nb_compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        cf_min = chan_freq.min()
-        cf_max = chan_freq.max()
-        cf_mid = (cf_min + cf_max) / 2
+        cf_mid = (ms_inputs.MIN_FREQ + ms_inputs.MAX_FREQ) / 2
 
         # Determine loop variables based on where we are in the chain.
         # gt means greater than (n>j) and lt means less than (n<j).
@@ -601,9 +598,7 @@ def nb_finalize_update(
                     params[..., pd, :] = 0
 
             chan_freq = ms_inputs.CHAN_FREQ
-            cf_min = chan_freq.min()
-            cf_max = chan_freq.max()
-            cf_mid = (cf_min + cf_max) / 2
+            cf_mid = (ms_inputs.MIN_FREQ + ms_inputs.MAX_FREQ) / 2
 
             for t in range(n_time):
                 for f in range(n_freq):
@@ -793,15 +788,15 @@ def delay_params_to_gains(
     params,
     gains,
     chan_freq,
+    min_freq,
+    max_freq,
     param_freq_map,
     rescaled=False
 ):
 
     n_time, n_freq, n_ant, n_dir, n_corr = gains.shape
 
-    cf_min = chan_freq.min()
-    cf_max = chan_freq.max()
-    cf_mid = (cf_min + cf_max) / 2
+    cf_mid = (min_freq + max_freq) / 2
 
     if rescaled:
         offset = 1.0
@@ -859,7 +854,13 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
                         p -= rp
 
     delay_params_to_gains(
-        params, gains, chan_freq, param_freq_map, rescaled=True
+        params,
+        gains,
+        chan_freq,
+        ms_inputs.MIN_FREQ,
+        ms_inputs.MAX_FREQ,
+        param_freq_map,
+        rescaled=True
     )
 
     # Referencing may move flagged gains/params from identity.

--- a/quartical/gains/delay_and_offset/__init__.py
+++ b/quartical/gains/delay_and_offset/__init__.py
@@ -13,7 +13,11 @@ from quartical.gains.general.flagging import (
 
 # Overload the default measurement set inputs to include the frequencies.
 ms_inputs = namedtuple(
-    'ms_inputs', ParameterizedGain.ms_inputs._fields + ('CHAN_FREQ',)
+    'ms_inputs', ParameterizedGain.ms_inputs._fields + (
+        'CHAN_FREQ',
+        'MIN_FREQ',
+        'MAX_FREQ'
+    )
 )
 
 
@@ -67,6 +71,8 @@ class DelayAndOffset(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 
@@ -165,6 +171,8 @@ class DelayAndOffset(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 

--- a/quartical/gains/delay_and_offset/kernel.py
+++ b/quartical/gains/delay_and_offset/kernel.py
@@ -2,26 +2,34 @@
 import numpy as np
 from numba import prange, njit
 from numba.extending import overload
-from quartical.utils.numba import (coerce_literal,
-                                   JIT_OPTIONS,
-                                   PARALLEL_JIT_OPTIONS)
-from quartical.gains.general.generics import (native_intermediaries,
-                                              upsampled_itermediaries,
-                                              per_array_jhj_jhr,
-                                              resample_solints,
-                                              downsample_jhj_jhr)
-from quartical.gains.general.flagging import (flag_intermediaries,
-                                              update_gain_flags,
-                                              finalize_gain_flags,
-                                              apply_gain_flags_to_flag_col,
-                                              update_param_flags,
-                                              apply_gain_flags_to_gains,
-                                              apply_param_flags_to_params)
-from quartical.gains.general.convenience import (get_row,
-                                                 get_extents)
+from quartical.utils.numba import (
+    coerce_literal,
+    JIT_OPTIONS,
+    PARALLEL_JIT_OPTIONS
+)
+from quartical.gains.general.generics import (
+    native_intermediaries,
+    upsampled_itermediaries,
+    per_array_jhj_jhr,
+    resample_solints,
+    downsample_jhj_jhr,
+    scalar_jhj_jhr
+)
+from quartical.gains.general.flagging import (
+    flag_intermediaries,
+    update_gain_flags,
+    finalize_gain_flags,
+    apply_gain_flags_to_flag_col,
+    update_param_flags,
+    apply_gain_flags_to_gains,
+    apply_param_flags_to_params
+)
+from quartical.gains.general.convenience import get_row, get_extents
 import quartical.gains.general.factories as factories
-from quartical.gains.general.inversion import (invert_factory,
-                                               inversion_buffer_factory)
+from quartical.gains.general.inversion import (
+    invert_factory,
+    inversion_buffer_factory
+)
 
 
 def get_identity_params(corr_mode):
@@ -88,6 +96,7 @@ def nb_delay_and_offset_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -150,6 +159,9 @@ def nb_delay_and_offset_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar and corr_mode != 1:
+                scalar_jhj_jhr(native_imdry, 2)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/delay_and_offset/kernel.py
+++ b/quartical/gains/delay_and_offset/kernel.py
@@ -138,8 +138,7 @@ def nb_delay_and_offset_solver_impl(
 
         # We actually solve for D' = (D(nu_min + nu_max))/2. This helps avoid
         # numerical issues, but requires some scaling of the parameters.
-        chan_freq = ms_inputs.CHAN_FREQ
-        mid_freq = (chan_freq.min() + chan_freq.max())/2
+        mid_freq = (ms_inputs.MIN_FREQ + ms_inputs.MAX_FREQ) / 2
         active_params[..., 1::2] *= mid_freq
 
         for loop_idx in range(max_iter or 1):
@@ -331,9 +330,7 @@ def nb_compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        cf_min = chan_freq.min()
-        cf_max = chan_freq.max()
-        cf_mid = (cf_min + cf_max) / 2
+        cf_mid = (ms_inputs.MIN_FREQ + ms_inputs.MAX_FREQ) / 2
 
         # Determine loop variables based on where we are in the chain.
         # gt means greater than (n>j) and lt means less than (n<j).
@@ -602,9 +599,7 @@ def nb_finalize_update(
                     params[..., pd, :] = 0
 
             chan_freq = ms_inputs.CHAN_FREQ
-            cf_min = chan_freq.min()
-            cf_max = chan_freq.max()
-            cf_mid = (cf_min + cf_max) / 2
+            cf_mid = (ms_inputs.MIN_FREQ + ms_inputs.MAX_FREQ) / 2
 
             for t in range(n_time):
                 for f in range(n_freq):
@@ -833,15 +828,15 @@ def delay_and_offset_params_to_gains(
     params,
     gains,
     chan_freq,
+    min_freq,
+    max_freq,
     param_freq_map,
     rescaled=False
 ):
 
     n_time, n_freq, n_ant, n_dir, n_corr = gains.shape
 
-    cf_min = chan_freq.min()
-    cf_max = chan_freq.max()
-    cf_mid = (cf_min + cf_max) / 2
+    cf_mid = (min_freq + max_freq) / 2
 
     if rescaled:
         offset = 1.0
@@ -899,7 +894,13 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
                         p -= rp
 
     delay_and_offset_params_to_gains(
-        params, gains, chan_freq, param_freq_map, rescaled=True
+        params,
+        gains,
+        chan_freq,
+        ms_inputs.MIN_FREQ,
+        ms_inputs.MAX_FREQ,
+        param_freq_map,
+        rescaled=True
     )
 
     # Referencing may move flagged gains/params from identity.

--- a/quartical/gains/delay_and_tec/__init__.py
+++ b/quartical/gains/delay_and_tec/__init__.py
@@ -13,7 +13,11 @@ from quartical.gains.general.flagging import (
 
 # Overload the default measurement set inputs to include the frequencies.
 ms_inputs = namedtuple(
-    'ms_inputs', ParameterizedGain.ms_inputs._fields + ('CHAN_FREQ',)
+    'ms_inputs', ParameterizedGain.ms_inputs._fields + (
+        'CHAN_FREQ',
+        'MIN_FREQ',
+        'MAX_FREQ'
+    )
 )
 
 
@@ -66,6 +70,8 @@ class DelayAndTec(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 
@@ -164,6 +170,8 @@ class DelayAndTec(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 

--- a/quartical/gains/delay_and_tec/kernel.py
+++ b/quartical/gains/delay_and_tec/kernel.py
@@ -9,7 +9,8 @@ from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
                                               resample_solints,
-                                              downsample_jhj_jhr)
+                                              downsample_jhj_jhr,
+                                              scalar_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
@@ -88,6 +89,7 @@ def nb_delay_and_tec_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -154,6 +156,9 @@ def nb_delay_and_tec_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar and corr_mode != 1:
+                scalar_jhj_jhr(native_imdry, 2)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/feed_flip/__init__.py
+++ b/quartical/gains/feed_flip/__init__.py
@@ -1,0 +1,47 @@
+import numpy as np
+from quartical.gains.gain import Gain
+from quartical.gains.conversion import amp_trig_to_complex
+
+
+class FeedFlip(Gain):
+
+    solver = None # This is not a solvable term.
+    # Conversion functions required for interpolation NOTE: Non-parameterised
+    # gains will always be reinterpreted and parameterised in amplitude and
+    # phase for the sake of simplicity.
+    # TODO: Make this a real valued term - took simple approach for now.
+    native_to_converted = (
+        (0, (np.abs,)),
+        (0, (np.angle, np.cos)),
+        (1, (np.angle, np.sin))
+    )
+    converted_to_native = (
+        (3, amp_trig_to_complex),
+    )
+    converted_dtype = np.float64
+    native_dtype = np.complex128
+
+    def __init__(self, term_name, term_opts):
+
+        super().__init__(term_name, term_opts)
+
+        self.time_interval = 0
+        self.freq_interval = 0
+
+    def init_term(self, term_spec, ref_ant, ms_kwargs, term_kwargs, meta=None):
+        """Initialise the gains (and parameters)."""
+
+        (_, _, gain_shape, _) = term_spec
+
+        gains = np.ones(gain_shape, dtype=np.complex128)
+
+        if gain_shape[-1] == 4:
+            gains[..., (0, 3)] = 0  # 2-by-2 antidiagonal.
+        else:
+            raise ValueError(
+                "Feed flip unsupported for less than four correlations"
+            )
+
+        gain_flags = np.zeros(gains.shape[:-1], dtype=np.int8)
+
+        return gains, gain_flags

--- a/quartical/gains/gain.py
+++ b/quartical/gains/gain.py
@@ -39,7 +39,8 @@ ms_inputs = namedtuple(
         "WEIGHT",
         "FLAG",
         "ROW_MAP",
-        "ROW_WEIGHTS"
+        "ROW_WEIGHTS",
+        "TIME"
     )
 )
 

--- a/quartical/gains/gain.py
+++ b/quartical/gains/gain.py
@@ -86,6 +86,7 @@ class Gain:
         self.name = term_name
         self.type = term_opts.type
         self.solve_per = term_opts.solve_per
+        self.scalar = term_opts.scalar
         self.direction_dependent = term_opts.direction_dependent
         self.pinned_directions = term_opts.pinned_directions
         self.time_interval = term_opts.time_interval

--- a/quartical/gains/leakage/kernel.py
+++ b/quartical/gains/leakage/kernel.py
@@ -73,6 +73,7 @@ def nb_leakage_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -128,6 +129,9 @@ def nb_leakage_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError("Scalar mode not supported for leakage terms.")
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/parallactic_angle/__init__.py
+++ b/quartical/gains/parallactic_angle/__init__.py
@@ -16,7 +16,7 @@ from quartical.data_handling.angles import _make_parangles
 ms_inputs = namedtuple(
     'ms_inputs', 
     ParameterizedGain.ms_inputs._fields + \
-        ('RECEPTOR_ANGLE', 'POSITION', 'TIME')
+        ('RECEPTOR_ANGLE', 'POSITION')
 )
 
 class ParallacticAngle(ParameterizedGain):
@@ -37,6 +37,10 @@ class ParallacticAngle(ParameterizedGain):
     def __init__(self, term_name, term_opts):
 
         super().__init__(term_name, term_opts)
+
+        # NOTE: Ignore user-specified values on this term.
+        self.time_interval = 1
+        self.freq_interval = 0
 
     @classmethod
     def _make_freq_map(cls, chan_freqs, chan_widths, freq_interval):

--- a/quartical/gains/parameterized_gain.py
+++ b/quartical/gains/parameterized_gain.py
@@ -14,7 +14,8 @@ ms_inputs = namedtuple(
         "WEIGHT",
         "FLAG",
         "ROW_MAP",
-        "ROW_WEIGHTS"
+        "ROW_WEIGHTS",
+        "TIME"
     )
 )
 

--- a/quartical/gains/phase/kernel.py
+++ b/quartical/gains/phase/kernel.py
@@ -9,7 +9,8 @@ from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
                                               resample_solints,
-                                              downsample_jhj_jhr)
+                                              downsample_jhj_jhr,
+                                              scalar_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
@@ -88,6 +89,7 @@ def nb_phase_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -144,6 +146,9 @@ def nb_phase_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar and corr_mode != 1:
+                scalar_jhj_jhr(native_imdry, 1)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/rotation/kernel.py
+++ b/quartical/gains/rotation/kernel.py
@@ -84,6 +84,7 @@ def nb_rotation_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -141,6 +142,11 @@ def nb_rotation_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError(
+                    "Scalar mode not supported for rotation terms."
+                )
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/rotation_measure/kernel.py
+++ b/quartical/gains/rotation_measure/kernel.py
@@ -84,6 +84,7 @@ def nb_rm_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -144,6 +145,11 @@ def nb_rm_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar:
+                raise ValueError(
+                    "Scalar mode not supported for rotation measure terms."
+                )
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/quartical/gains/tec_and_offset/__init__.py
+++ b/quartical/gains/tec_and_offset/__init__.py
@@ -13,7 +13,11 @@ from quartical.gains.general.flagging import (
 
 # Overload the default measurement set inputs to include the frequencies.
 ms_inputs = namedtuple(
-    'ms_inputs', ParameterizedGain.ms_inputs._fields + ('CHAN_FREQ',)
+    'ms_inputs', ParameterizedGain.ms_inputs._fields + (
+        'CHAN_FREQ',
+        'MIN_FREQ',
+        'MAX_FREQ'
+    )
 )
 
 
@@ -67,6 +71,8 @@ class TecAndOffset(ParameterizedGain):
             params,
             gains,
             ms_kwargs["CHAN_FREQ"],
+            ms_kwargs["MIN_FREQ"],
+            ms_kwargs["MAX_FREQ"],
             term_kwargs[f"{self.name}_param_freq_map"],
         )
 

--- a/quartical/gains/tec_and_offset/kernel.py
+++ b/quartical/gains/tec_and_offset/kernel.py
@@ -133,8 +133,7 @@ def nb_tec_and_offset_solver_impl(
 
         # We actually solve for TEC' = TEC/bandwidth. This helps avoid
         # numerical issues, but requires some scaling of the parameters.
-        chan_freq = ms_inputs.CHAN_FREQ
-        bandwidth = chan_freq.max() - chan_freq.min()
+        bandwidth = ms_inputs.MAX_FREQ - ms_inputs.MIN_FREQ
         active_params[..., 1::2] /= bandwidth
 
         for loop_idx in range(max_iter or 1):
@@ -326,8 +325,8 @@ def nb_compute_jhj_jhr(
 
         n_gains = len(gains)
 
-        cf_min = chan_freq.min()
-        cf_max = chan_freq.max()
+        cf_min = ms_inputs.MIN_FREQ
+        cf_max = ms_inputs.MAX_FREQ
         bandwidth = cf_max - cf_min
         offset = np.log(cf_min / cf_max)
 
@@ -598,8 +597,8 @@ def nb_finalize_update(
                     params[..., pd, :] = 0
 
             chan_freq = ms_inputs.CHAN_FREQ
-            cf_min = chan_freq.min()
-            cf_max = chan_freq.max()
+            cf_min = ms_inputs.MIN_FREQ
+            cf_max = ms_inputs.MAX_FREQ
             bandwidth = cf_max - cf_min
             offset = np.log(cf_min/cf_max)
 
@@ -830,14 +829,16 @@ def tec_and_offset_params_to_gains(
     params,
     gains,
     chan_freq,
+    min_freq,
+    max_freq,
     param_freq_map,
     rescaled=False
 ):
 
     n_time, n_freq, n_ant, n_dir, n_corr = gains.shape
 
-    cf_min = chan_freq.min()
-    cf_max = chan_freq.max()
+    cf_min = min_freq
+    cf_max = max_freq
     bandwidth = cf_max - cf_min
 
     # The log term absorbs the leading factor of -1, inverting the fraction.
@@ -897,7 +898,13 @@ def reference_params(ms_inputs, mapping_inputs, chain_inputs, meta_inputs):
                         p -= rp
 
     tec_and_offset_params_to_gains(
-        params, gains, chan_freq, param_freq_map, rescaled=True
+        params,
+        gains,
+        chan_freq,
+        ms_inputs.MIN_FREQ,
+        ms_inputs.MAX_FREQ,
+        param_freq_map,
+        rescaled=True
     )
 
     # Referencing may move flagged gains/params from identity.

--- a/quartical/gains/tec_and_offset/kernel.py
+++ b/quartical/gains/tec_and_offset/kernel.py
@@ -9,7 +9,8 @@ from quartical.gains.general.generics import (native_intermediaries,
                                               upsampled_itermediaries,
                                               per_array_jhj_jhr,
                                               resample_solints,
-                                              downsample_jhj_jhr)
+                                              downsample_jhj_jhr,
+                                              scalar_jhj_jhr)
 from quartical.gains.general.flagging import (flag_intermediaries,
                                               update_gain_flags,
                                               finalize_gain_flags,
@@ -90,6 +91,7 @@ def nb_tec_and_offset_solver_impl(
         active_term = meta_inputs.active_term
         max_iter = meta_inputs.iters
         solve_per = meta_inputs.solve_per
+        scalar = meta_inputs.scalar
         dd_term = meta_inputs.dd_term
         n_thread = meta_inputs.threads
 
@@ -152,6 +154,9 @@ def nb_tec_and_offset_solver_impl(
 
             if solve_per == "array":
                 per_array_jhj_jhr(native_imdry)
+
+            if scalar and corr_mode != 1:
+                scalar_jhj_jhr(native_imdry, 2)
 
             if not max_iter:  # Non-solvable term, we just want jhj.
                 conv_perc = 0  # Didn't converge.

--- a/testing/fixtures/gains.py
+++ b/testing/fixtures/gains.py
@@ -25,3 +25,8 @@ def cmp_post_solve_data_xds_list(cmp_calibration_graph_outputs):
 @pytest.fixture(params=["antenna", "array"], scope="module")
 def solve_per(request):
     return request.param
+
+
+@pytest.fixture(params=[True, False], scope="module")
+def scalar_mode(request):
+    return request.param

--- a/testing/tests/gains/test_amplitude.py
+++ b/testing/tests/gains/test_amplitude.py
@@ -7,7 +7,7 @@ from quartical.calibration.calibrate import add_calibration_graph
 
 
 @pytest.fixture(scope="module")
-def opts(base_opts, select_corr, solve_per):
+def opts(base_opts, select_corr, solve_per, scalar_mode):
 
     # Don't overwrite base config - instead create a copy and update.
 
@@ -22,6 +22,7 @@ def opts(base_opts, select_corr, solve_per):
     _opts.solver.threads = 2
     _opts.G.type = "amplitude"
     _opts.G.solve_per = solve_per
+    _opts.G.scalar = scalar_mode
 
     return _opts
 
@@ -33,7 +34,7 @@ def raw_xds_list(read_xds_list_output):
 
 
 @pytest.fixture(scope="module")
-def true_gain_list(predicted_xds_list, solve_per):
+def true_gain_list(predicted_xds_list, solve_per, scalar_mode):
 
     gain_list = []
 
@@ -65,6 +66,9 @@ def true_gain_list(predicted_xds_list, solve_per):
             amp *= da.array([1, 0, 0, 1])
 
         gains = amp*da.exp(1j*phase)
+
+        if scalar_mode:
+            gains[..., -1] = gains[..., 0]
 
         if solve_per == "array":
             gains = da.broadcast_to(gains[:, :, :1], gains.shape)

--- a/testing/tests/gains/test_delay_and_offset.py
+++ b/testing/tests/gains/test_delay_and_offset.py
@@ -7,7 +7,7 @@ from testing.utils.gains import apply_gains, reference_gains
 
 
 @pytest.fixture(scope="module")
-def opts(base_opts, select_corr):
+def opts(base_opts, select_corr, scalar_mode):
 
     # Don't overwrite base config - instead create a copy and update.
 
@@ -23,6 +23,7 @@ def opts(base_opts, select_corr):
     _opts.G.type = "delay_and_offset"
     _opts.G.freq_interval = 0
     _opts.G.initial_estimate = True
+    _opts.G.scalar = scalar_mode
 
     return _opts
 
@@ -34,7 +35,7 @@ def raw_xds_list(read_xds_list_output):
 
 
 @pytest.fixture(scope="module")
-def true_gain_list(predicted_xds_list):
+def true_gain_list(predicted_xds_list, scalar_mode):
 
     gain_list = []
 
@@ -81,6 +82,9 @@ def true_gain_list(predicted_xds_list):
         origin_chan_freq = origin_chan_freq[None, :, None, None, None]
         phase = 2*np.pi*delays*origin_chan_freq + offsets
         gains = amp*da.exp(1j*phase)
+
+        if scalar_mode:
+            gains[..., -1] = gains[..., 0]
 
         gain_list.append(gains)
 

--- a/testing/tests/gains/test_diag_complex.py
+++ b/testing/tests/gains/test_diag_complex.py
@@ -12,7 +12,7 @@ def solver_type(request):
 
 
 @pytest.fixture(scope="module")
-def opts(base_opts, solver_type, select_corr, solve_per):
+def opts(base_opts, solver_type, select_corr, solve_per, scalar_mode):
 
     # Don't overwrite base config - instead create a copy and update.
 
@@ -27,6 +27,7 @@ def opts(base_opts, solver_type, select_corr, solve_per):
     _opts.solver.threads = 2
     _opts.G.type = solver_type
     _opts.G.solve_per = solve_per
+    _opts.G.scalar = scalar_mode
 
     return _opts
 
@@ -38,7 +39,7 @@ def raw_xds_list(read_xds_list_output):
 
 
 @pytest.fixture(scope="module")
-def true_gain_list(predicted_xds_list, solve_per):
+def true_gain_list(predicted_xds_list, solve_per, scalar_mode):
 
     gain_list = []
 
@@ -68,6 +69,9 @@ def true_gain_list(predicted_xds_list, solve_per):
             amp *= da.array([1, 0, 0, 1])
 
         gains = amp*da.exp(1j*phase)
+
+        if scalar_mode:
+            gains[..., -1] = gains[..., 0]
 
         if solve_per == "array":
             gains = da.broadcast_to(gains[:, :, :1], gains.shape)

--- a/testing/tests/gains/test_phase.py
+++ b/testing/tests/gains/test_phase.py
@@ -7,7 +7,7 @@ from testing.utils.gains import apply_gains, reference_gains
 
 
 @pytest.fixture(scope="module")
-def opts(base_opts, select_corr, solve_per):
+def opts(base_opts, select_corr, solve_per, scalar_mode):
 
     # Don't overwrite base config - instead create a copy and update.
 
@@ -22,6 +22,7 @@ def opts(base_opts, select_corr, solve_per):
     _opts.solver.threads = 2
     _opts.G.type = "phase"
     _opts.G.solve_per = solve_per
+    _opts.G.scalar = scalar_mode
 
     return _opts
 
@@ -33,7 +34,7 @@ def raw_xds_list(read_xds_list_output):
 
 
 @pytest.fixture(scope="module")
-def true_gain_list(predicted_xds_list, solve_per):
+def true_gain_list(predicted_xds_list, solve_per, scalar_mode):
 
     gain_list = []
 
@@ -63,6 +64,9 @@ def true_gain_list(predicted_xds_list, solve_per):
             amp *= da.array([1, 0, 0, 1])
 
         gains = amp*da.exp(1j*phase)
+
+        if scalar_mode:
+            gains[..., -1] = gains[..., 0]
 
         if solve_per == "array":
             gains = da.broadcast_to(gains[:, :, :1], gains.shape)


### PR DESCRIPTION
This is a WIP PR which forms part of our campaign to figure out how we can leverage the noise diodes for performing polarization calibration in the absence of a polarized calibrator (in the observation). This is can be accomplished by deriving the crosshand phases from the mean XY phase on the reference antenna (in addition to bootstrapping a temporally stable component - more on this later). @Mulan-94 - you can use this on noise diode data to produce a QC gain dataset with the estimated solutions. Your config will need to look something like the following:
```yaml
input_ms:
  path: noisediode.uncorrected.ms
  data_column: DATA
  time_chunk: '0'
  freq_chunk: '0'
solver:
  terms:
  - X
  iter_recipe:
  - 0
  reference_antenna: 2
X:
  type: crosshand_phase_null_v
  solve_per: array
  time_interval: 0
  freq_interval: '1'
  initial_estimate: true
```

Note that setting `solve_per` to `antenna` will produce an estimate per antenna but the resulting dataset will have an ambiguous reference antenna i.e. it is useful for visualisation but useless for calibrating.  https://github.com/JSKenyon/QuartiCal-Visualiser can be used for some basic inspection.

Tagging @o-smirnov, @landmanbester and @bennahugo for the sake of visibility.