### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,12 @@ classifiers = [
 ]
 dependencies = [
     "astro-tigger-lsm>=1.8.0,<=1.8.0",
+    # bokeh is capped at <3.7: bokeh 3.7.0 renamed its bundled templates to
+    # add a .jinja suffix (file.html -> file.html.jinja), but distributed
+    # 2024.10.0's performance_report.html still does {% extends "file.html" %}.
+    # The mismatch raises TemplateNotFound('file.html') when compute_context's
+    # performance_report writes its HTML report on exit.
+    "bokeh>=2.4.2,<3.7",
     "codex-africanus[dask,scipy,astropy,python-casacore]>=0.4.1,<=0.4.4",
     "colorama>=0.4.6,<=0.4.6",
     "columnar>=1.4.1,<=1.4.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 authors = [
     {name = "Jonathan Kenyon", email = "jonathan.simon.kenyon@gmail.com"},
 ]
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
@@ -17,22 +17,27 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dependencies = [
     "astro-tigger-lsm>=1.8.0,<=1.8.0",
-    "codex-africanus[dask,scipy,astropy,python-casacore]>=0.4.1,<=0.4.3",
+    "codex-africanus[dask,scipy,astropy,python-casacore]>=0.4.1,<=0.4.4",
     "colorama>=0.4.6,<=0.4.6",
     "columnar>=1.4.1,<=1.4.1",
+    # dask is capped at 2024.10.0: dask 2024.12.0 introduced a
+    # fuse_linear_task_spec array optimizer that fails on dask-ms read graphs
+    # (clone()[0] in ms_handler), and 2024.11.x is incompatible with dask-ms's
+    # task inlining. See the failing graph fusion in make_gain_xds_lod.
     "dask[diagnostics]>=2023.5.0,<=2024.10.0",
-    "dask-ms[s3,xarray,zarr]>=0.2.23,<=0.2.27",
+    "dask-ms[s3,xarray,zarr]>=0.2.23,<=0.2.32",
     "distributed>=2023.5.0,<=2024.10.0",
     "loguru>=0.7.0,<=0.7.3",
-    "matplotlib>=3.5.1,<=3.9.2",
-    "omegaconf>=2.3.0,<=2.3.0",
-    "requests>=2.31.0,<=2.32.5",
+    "matplotlib>=3.5.1,<=3.10.9",
+    "omegaconf>=2.3.0,<=2.3.1",
+    "requests>=2.31.0,<=2.34.2",
     "ruamel.yaml>=0.17.26,<=0.19.1",
-    "stimela>=2.0",
+    "stimela>=2.1.4",  # Do not include an upper bound on stimela.
 ]
 
 [project.urls]
@@ -49,7 +54,7 @@ goquartical-plot = "quartical.apps.plotter:plot"
 
 [dependency-groups]
 dev = [
-    "pytest>=7.3.1,<=9.0.2",
+    "pytest>=7.3.1,<=9.0.3",
     "tbump>=6.10.0,<=6.11.0",
 ]
 


### PR DESCRIPTION
Attempt to relax the QC dependencies and add Python 3.13 support. Upgrading `dask` still poses a problem due to the use of `clone` (and likely the `Blocker` class). `clone` is not well supported in newer versions of `dask`: `Task` objects are not properly handled. 

- https://github.com/ratt-ru/dask-ms/issues/374
- https://github.com/dask/dask/issues/12455 (dask bug report)

**Edit** Added dask-ms issue, dask issue