### PR TITLE
test: support parallel test runs with pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ goquartical-plot = "quartical.apps.plotter:plot"
 [dependency-groups]
 dev = [
     "pytest>=7.3.1,<=9.0.3",
+    "pytest-xdist>=3.5.0,<=3.8.0",
     "tbump>=6.10.0,<=6.11.0",
 ]
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -43,6 +43,16 @@ dat_pth_list = [ms_path, ms_4k_path, beam_path]
 def pytest_sessionstart(session):
     """Called after Session object has been created, before run test loop."""
 
+    # Under pytest-xdist this hook fires in the controller and in every worker.
+    # Only the controller should manage the shared test data: its sessionstart
+    # completes before any worker is spawned, so downloading here guarantees the
+    # data is present on disk before the workers begin collecting. Letting the
+    # workers run this too would race multiple concurrent downloads onto the same
+    # files. Workers carry a ``workerinput`` attribute on their config; the
+    # controller does not.
+    if hasattr(session.config, "workerinput"):
+        return
+
     if all([p.exists() for p in dat_pth_list]):
         print("Test data already present - not downloading.")
     else:
@@ -58,6 +68,13 @@ def pytest_sessionstart(session):
 
 def pytest_sessionfinish(session, exitstatus):
     """Called after test run finished, before returning exit status."""
+
+    # Under pytest-xdist only the controller may remove the shared test data,
+    # and only once every worker has finished (the controller's sessionfinish
+    # runs last). If the workers ran this, the first worker to finish would
+    # rmtree the data out from under the others mid-run.
+    if hasattr(session.config, "workerinput"):
+        return
 
     for pth in dat_pth_list:
         if pth.exists():

--- a/testing/tests/data_handling/test_ms_handler.py
+++ b/testing/tests/data_handling/test_ms_handler.py
@@ -1,4 +1,6 @@
+import shutil
 from copy import deepcopy
+from pathlib import Path
 import pytest
 from quartical.data_handling.ms_handler import write_xds_list
 import numpy as np
@@ -71,14 +73,31 @@ def test_read_ms_freq_chunks(raw_xds_list, ms_opts):
 # -------------------------------write_xds_list--------------------------------
 
 @pytest.fixture(scope="module")
-def written_xds_list(raw_xds_list, ref_xds_list, ms_name, output_opts):
+def writable_ms(ms_name, tmp_path_factory):
+    # write_xds_list creates its output columns on disk at graph-build time,
+    # which mutates the target table's column schema. Under pytest-xdist the
+    # other workers hold the shared MS open for reading and would then fail with
+    # "Table::lock cannot sync ... another process changed the number of
+    # columns". Redirect the write onto a private copy of the MS instead. Under
+    # xdist tmp_path_factory is rooted in a per-worker temporary directory, so
+    # each worker gets its own copy; module scope means we copy once per worker
+    # rather than once per parameter combination (writable_ms depends on no
+    # parametrised fixtures, so pytest caches it for the whole module).
+    ms_copy = tmp_path_factory.mktemp("writable_ms") / Path(ms_name).name
+    shutil.copytree(ms_name, ms_copy)
+
+    return str(ms_copy)
+
+
+@pytest.fixture(scope="module")
+def written_xds_list(raw_xds_list, ref_xds_list, writable_ms, output_opts):
 
     raw_xds_list = [xds.assign({"_RESIDUAL": xds.DATA,
                                 "_CORRECTED_DATA": xds.DATA,
                                 "_CORRECTED_RESIDUAL": xds.DATA})
                     for xds in raw_xds_list]
 
-    return write_xds_list(raw_xds_list, ref_xds_list, ms_name, output_opts)
+    return write_xds_list(raw_xds_list, ref_xds_list, writable_ms, output_opts)
 
 
 @pytest.mark.data_handling


### PR DESCRIPTION
## Summary

Makes the test suite safe to run under `pytest -n <N>` (pytest-xdist). Running in parallel previously produced hundreds of identical errors:

```
RuntimeError: Table::lock cannot sync table .../C147_subset.MS;
another process changed the number of columns
```

plus an end-of-run hang at high worker counts. Two independent root causes are fixed.

### 1. Shared-MS write contention (the lock errors)

`test_ms_handler.py::test_write_columns_present` wrote output columns directly onto the shared, session-scoped MS via `write_xds_list`. `xds_to_storage_table` creates those columns on disk at graph-build time, mutating the table's column schema. Every other worker holding the same MS open for reading then failed to re-sync its table lock — so the errors surfaced on the *reader* tests (delay, rotation, ...), not the writer.

**Fix:** redirect the write onto a private per-worker copy of the MS via a new module-scoped `writable_ms` fixture backed by `tmp_path_factory` (which is per-worker under xdist). Copied once per worker, not once per parameter combination.

### 2. Session hooks racing across workers (download + cleanup)

`pytest_sessionstart` / `pytest_sessionfinish` fire in the controller *and* in every worker. Concurrent workers raced the test-data download, and the first worker to finish would `rmtree` the data out from under the others.

**Fix:** gate both hooks to the controller node (the one without a `workerinput` attribute). Its sessionstart runs before any worker spawns; its sessionfinish runs after all workers finish.

### Also
- Declares `pytest-xdist` as a `dev` dependency.

## Verification
- Full suite at `-n 8`: **1195 passed, 5 xfailed, 0 errors** (the worker count that previously produced 240 lock errors + a hang).
- Suite still passes serially.

Note: on a memory-constrained machine, `-n 6`–`-n 8` is recommended over higher counts (a separate capacity/swap limit, unrelated to the fixed lock errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)